### PR TITLE
Remove stream

### DIFF
--- a/basic_network.go
+++ b/basic_network.go
@@ -182,7 +182,7 @@ func (n *BasicVideoNetwork) SetupProtocol() error {
 		for {
 			if err := streamHandler(n, ws); err != nil {
 				glog.Errorf("Error handling stream: %v", err)
-				delete(n.NetworkNode.streams, stream.Conn().RemotePeer())
+				n.NetworkNode.RemoveStream(stream.Conn().RemotePeer())
 				stream.Close()
 				return
 			}
@@ -196,7 +196,7 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 	var msg Msg
 
 	if err := ws.ReceiveMessage(&msg); err != nil {
-		glog.Errorf("Got error decoding msg: %v", err)
+		glog.Errorf("%v Got error decoding msg: %v", peer.IDHexEncode(ws.Stream.Conn().LocalPeer()), err)
 		return err
 	}
 	glog.Infof("%v Received a message %v from %v", peer.IDHexEncode(ws.Stream.Conn().LocalPeer()), msg.Op, peer.IDHexEncode(ws.Stream.Conn().RemotePeer()))
@@ -298,7 +298,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 				if ns != nil {
 					if err := ns.SendMessage(SubReqID, subReq); err != nil {
 						//Question: Do we want to close the stream here?
-						glog.Errorf("Error relaying subReq to %v: %v", p, err)
+						glog.Errorf("Error relaying subReq to %v: %v.", p, err)
 						continue
 					}
 
@@ -428,7 +428,7 @@ func handleTranscodeResponse(nw *BasicVideoNetwork, tr TranscodeResponseMsg) err
 func handleGetMasterPlaylistReq(nw *BasicVideoNetwork, ws *BasicStream, mplr GetMasterPlaylistReqMsg) error {
 	mpl, ok := nw.mplMap[mplr.StrmID]
 	if !ok {
-		glog.Errorf("Got master playlist request, but can't find the playlist")
+		glog.Errorf("Got master playlist request for %v, but can't find the playlist", mplr.StrmID)
 		return ws.SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, NotFound: true})
 	}
 

--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -55,6 +55,41 @@ type keyPair struct {
 	Pub  crypto.PubKey
 }
 
+func TestReconnect(t *testing.T) {
+	priv1, pub1, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	no1, _ := NewNode(15000, priv1, pub1, NewBasicNotifiee(nil))
+	n1, _ := NewBasicVideoNetwork(no1)
+
+	priv2, pub2, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	no2, _ := NewNode(15001, priv2, pub2, &BasicNotifiee{})
+	n2, _ := NewBasicVideoNetwork(no2)
+	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
+	go n1.SetupProtocol()
+	go n2.SetupProtocol()
+
+	//Send a message, it should work
+	s := n2.NetworkNode.GetStream(n1.NetworkNode.Identity)
+	if err := s.SendMessage(GetMasterPlaylistReqID, GetMasterPlaylistReqMsg{StrmID: "strmID1"}); err != nil {
+		t.Errorf("Error sending message: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	//Kill n2, create a new n2
+	n2.NetworkNode.PeerHost.Close()
+	no2, _ = NewNode(15001, priv2, pub2, &BasicNotifiee{})
+	n2, _ = NewBasicVideoNetwork(no2)
+	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
+	s = n2.NetworkNode.GetStream(n1.NetworkNode.Identity)
+
+	//Send should still work
+	if err := s.SendMessage(GetMasterPlaylistReqID, GetMasterPlaylistReqMsg{StrmID: "strmID3"}); err != nil {
+		t.Errorf("Error sending message: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}
+
 func TestSubPeerForwardPath(t *testing.T) {
 	keys := make([]keyPair, 3)
 	for i := 0; i < 3; i++ {
@@ -575,21 +610,29 @@ func TestSendTranscodeResponse(t *testing.T) {
 
 func TestMasterPlaylist(t *testing.T) {
 	glog.Infof("\n\nTesting handle master playlist")
-	n1, n2 := setupNodes()
+	n1, _ := setupNodes()
+
+	priv, pub, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	no2, _ := NewNode(15003, priv, pub, &BasicNotifiee{})
+	n2, _ := NewBasicVideoNetwork(no2)
+
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
 	go n1.SetupProtocol()
+	go n2.SetupProtocol()
 
+	//Create Playlist
 	mpl := m3u8.NewMasterPlaylist()
 	pl, _ := m3u8.NewMediaPlaylist(10, 10)
 	mpl.Append("test.m3u8", pl, m3u8.VariantParams{Bandwidth: 100000})
-	strmID := "12209433a695c8bf34ef6a40863cfe7ed64266d876176aee13732293b63ba1637fd2531f50f9e8f99a37b48d7cfe12fa498ff6da8d6b63279b4632101d5e8b1c872c"
+	strmID := fmt.Sprintf("%vba1637fd2531f50f9e8f99a37b48d7cfe12fa498ff6da8d6b63279b4632101d5e8b1c872c", peer.IDHexEncode(n1.NetworkNode.Identity))
 
-	err := n1.UpdateMasterPlaylist(strmID, mpl)
-	if err != nil {
+	//n2 Updates Playlist
+	if err := n2.UpdateMasterPlaylist(strmID, mpl); err != nil {
 		t.Errorf("Error updating master playlist")
 	}
 
-	mplc, err := n2.GetMasterPlaylist(n1.GetNodeID(), strmID)
+	//n1 Gets Playlist
+	mplc, err := n1.GetMasterPlaylist(n2.GetNodeID(), strmID)
 	if err != nil {
 		t.Errorf("Error getting master playlist: %v", err)
 	}
@@ -603,6 +646,41 @@ func TestMasterPlaylist(t *testing.T) {
 	case <-timer.C:
 		t.Errorf("Timed out")
 	}
+
+	//Close down n2, recreate n2 (this could happen when n2 temporarily loses connectivity)
+	n2.NetworkNode.PeerHost.Close()
+	no2, _ = NewNode(15003, priv, pub, &BasicNotifiee{})
+	n2, _ = NewBasicVideoNetwork(no2)
+	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
+
+	//Create Playlist should still work
+	mpl = m3u8.NewMasterPlaylist()
+	pl, _ = m3u8.NewMediaPlaylist(10, 10)
+	mpl.Append("test2.m3u8", pl, m3u8.VariantParams{Bandwidth: 100000})
+	strmID = fmt.Sprintf("%vba1637fd2531f50f9e8f99a37b48d7cfe12fa498ff6da8d6b63279b4632101d5e8b1c872d", peer.IDHexEncode(n1.NetworkNode.Identity))
+	if err := n2.UpdateMasterPlaylist(strmID, mpl); err != nil {
+		t.Errorf("Error updating master playlist: %v", err)
+	}
+
+	//Get Playlist should still work
+	mplc, err = n1.GetMasterPlaylist(n2.GetNodeID(), strmID)
+	if err != nil {
+		t.Errorf("Error getting master playlist: %v", err)
+	}
+	timer = time.NewTimer(time.Second * 3)
+	select {
+	case r := <-mplc:
+		vars := r.Variants
+		if len(vars) != 1 {
+			t.Errorf("Expecting 1 variants, but got: %v - %v", len(vars), r)
+		}
+		if r.Variants[0].URI != "test2.m3u8" {
+			t.Errorf("Expecting test2.m3u8, got %v", r.Variants[0].URI)
+		}
+	case <-timer.C:
+		t.Errorf("Timed out")
+	}
+
 }
 
 func TestID(t *testing.T) {

--- a/basic_notifiee.go
+++ b/basic_notifiee.go
@@ -11,7 +11,8 @@ import (
 
 //BasicNotifiee gets called during important libp2p events
 type BasicNotifiee struct {
-	monitor *lpmon.Monitor
+	monitor           *lpmon.Monitor
+	disconnectHandler func(pid peer.ID)
 }
 
 func NewBasicNotifiee(mon *lpmon.Monitor) *BasicNotifiee {
@@ -42,6 +43,13 @@ func (bn *BasicNotifiee) Disconnected(n net.Network, conn net.Conn) {
 	if bn.monitor != nil {
 		bn.monitor.RemoveConn(peer.IDHexEncode(conn.LocalPeer()), peer.IDHexEncode(conn.RemotePeer()))
 	}
+	if bn.disconnectHandler != nil {
+		bn.disconnectHandler(conn.RemotePeer())
+	}
+}
+
+func (bn *BasicNotifiee) HandleDisconnect(h func(pid peer.ID)) {
+	bn.disconnectHandler = h
 }
 
 // called when a stream opened

--- a/basic_stream.go
+++ b/basic_stream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 	net "gx/ipfs/QmahYsGWry85Y7WUe2SX5G4JkH2zifEQAUtJVLZ24aC9DF/go-libp2p-net"
 
 	multicodec "gx/ipfs/QmVRuqGJ881CFiNLgwWSfRVjTjqQ6FeCNufkftNC4fpACZ/go-multicodec"
@@ -70,13 +71,13 @@ func (bs *BasicStream) encodeAndFlush(n interface{}) error {
 	defer bs.el.Unlock()
 	err := bs.enc.Encode(n)
 	if err != nil {
-		glog.Errorf("send message encode error: %v", err)
+		glog.Errorf("send message encode error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
 		return ErrStream
 	}
 
 	err = bs.w.Flush()
 	if err != nil {
-		glog.Errorf("send message flush error: %v", err)
+		glog.Errorf("send message flush error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
 		return ErrStream
 	}
 

--- a/network_node.go
+++ b/network_node.go
@@ -14,7 +14,6 @@ import (
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 	host "gx/ipfs/QmZy7c24mmkEHpNJndwgsEE3wcVxHd8yB969yTnAJFVw7f/go-libp2p-host"
 	crypto "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
-	inet "gx/ipfs/QmahYsGWry85Y7WUe2SX5G4JkH2zifEQAUtJVLZ24aC9DF/go-libp2p-net"
 	swarm "gx/ipfs/QmaijwHnbD4SabGA8C2fN9gchptLvRe2RxqTU5XkjAGBw5/go-libp2p-swarm"
 	bhost "gx/ipfs/QmapADMpK4e5kFGBxC2aHreaDqKP9vmMng5f91MA14Ces9/go-libp2p/p2p/host/basic"
 	rhost "gx/ipfs/QmapADMpK4e5kFGBxC2aHreaDqKP9vmMng5f91MA14Ces9/go-libp2p/p2p/host/routed"
@@ -29,11 +28,13 @@ type NetworkNode struct {
 }
 
 //NewNode creates a new Livepeerd node.
-func NewNode(listenPort int, priv crypto.PrivKey, pub crypto.PubKey, f inet.Notifiee) (*NetworkNode, error) {
+func NewNode(listenPort int, priv crypto.PrivKey, pub crypto.PubKey, f *BasicNotifiee) (*NetworkNode, error) {
 	pid, err := peer.IDFromPublicKey(pub)
 	if err != nil {
 		return nil, err
 	}
+
+	streams := make(map[peer.ID]*BasicStream)
 
 	// Create a peerstore
 	store := peerstore.NewPeerstore()
@@ -74,7 +75,12 @@ func NewNode(listenPort int, priv crypto.PrivKey, pub crypto.PubKey, f inet.Noti
 	rHost := rhost.Wrap(basicHost, dht)
 
 	glog.Infof("Created node: %v at %v", peer.IDHexEncode(rHost.ID()), rHost.Addrs())
-	return &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, streams: make(map[peer.ID]*BasicStream)}, nil
+	nn := &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, streams: streams}
+	f.HandleDisconnect(func(pid peer.ID) {
+		nn.RemoveStream(pid)
+	})
+
+	return nn, nil
 }
 
 func constructDHTRouting(ctx context.Context, host host.Host, dstore ds.Batching) (*kad.IpfsDHT, error) {
@@ -98,15 +104,24 @@ func constructDHTRouting(ctx context.Context, host host.Host, dstore ds.Batching
 func (n *NetworkNode) GetStream(pid peer.ID) *BasicStream {
 	strm, ok := n.streams[pid]
 	if !ok {
-		glog.Infof("Creating stream from %v to %v", peer.IDHexEncode(n.Identity), peer.IDHexEncode(pid))
-		ns, err := n.PeerHost.NewStream(context.Background(), pid, Protocol)
-		if err != nil {
-			glog.Errorf("Error creating stream to %v: %v", peer.IDHexEncode(pid), err)
-			return nil
-		}
-		strm = NewBasicStream(ns)
-		n.streams[pid] = strm
+		strm = n.RefreshStream(pid)
 	}
-
 	return strm
+}
+
+func (n *NetworkNode) RefreshStream(pid peer.ID) *BasicStream {
+	// glog.Infof("Creating stream from %v to %v", peer.IDHexEncode(n.Identity), peer.IDHexEncode(pid))
+	ns, err := n.PeerHost.NewStream(context.Background(), pid, Protocol)
+	if err != nil {
+		glog.Errorf("Error creating stream to %v: %v", peer.IDHexEncode(pid), err)
+		return nil
+	}
+	strm := NewBasicStream(ns)
+	n.streams[pid] = strm
+	return strm
+}
+
+func (n *NetworkNode) RemoveStream(pid peer.ID) {
+	// glog.Infof("Removing stream for %v", peer.IDHexEncode(pid))
+	delete(n.streams, pid)
 }


### PR DESCRIPTION
We should remove the stream when the remote host disconnects.  This can happen when the host temporarily loses connectivity.