### PR TITLE
hot fix network bug

### DIFF
--- a/basic_broadcaster.go
+++ b/basic_broadcaster.go
@@ -22,8 +22,6 @@ type BasicBroadcaster struct {
 
 //Broadcast sends a video chunk to the stream.  The very first call to Broadcast kicks off a worker routine to do the broadcasting.
 func (b *BasicBroadcaster) Broadcast(seqNo uint64, data []byte) error {
-	glog.V(5).Infof("Broadcasting data: %v (%v), storing in q: %v", seqNo, len(data), b)
-
 	//This should only get invoked once per broadcaster
 	if b.working == false {
 		ctxB, cancel := context.WithCancel(context.Background())
@@ -63,7 +61,6 @@ func (b *BasicBroadcaster) broadcastToListeners(ctx context.Context) {
 	for {
 		select {
 		case msg := <-b.q:
-			glog.V(6).Infof("broadcasting msg:%v to network.  listeners: %v", msg, b.listeners)
 			for id, l := range b.listeners {
 				// glog.Infof("Broadcasting segment %v to listener %v", msg.SeqNo, id)
 				b.sendDataMsg(id, l, msg)

--- a/basic_stream.go
+++ b/basic_stream.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"sync"
 
-	multicodec "github.com/multiformats/go-multicodec"
-	mcjson "github.com/multiformats/go-multicodec/json"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 	net "gx/ipfs/QmahYsGWry85Y7WUe2SX5G4JkH2zifEQAUtJVLZ24aC9DF/go-libp2p-net"
+
+	multicodec "github.com/multiformats/go-multicodec"
+	mcjson "github.com/multiformats/go-multicodec/json"
 
 	"github.com/golang/glog"
 )
@@ -57,7 +58,6 @@ func (bs *BasicStream) ReceiveMessage(n interface{}) error {
 //SendMessage writes a message into the stream.
 func (bs *BasicStream) SendMessage(opCode Opcode, data interface{}) error {
 	msg := Msg{Op: opCode, Data: data}
-	glog.V(5).Infof("Sending: %v to %v", msg, peer.IDHexEncode(bs.Stream.Conn().RemotePeer()))
 	return bs.encodeAndFlush(msg)
 }
 

--- a/basic_subscriber.go
+++ b/basic_subscriber.go
@@ -92,7 +92,6 @@ func (s *BasicSubscriber) startWorker(ctxW context.Context, p peer.ID, ws *Basic
 			//Question: What happens if the handler gets stuck?
 			select {
 			case msg := <-s.msgChan:
-				glog.V(5).Infof("Got data from msgChan: %v", msg)
 				gotData(msg.SeqNo, msg.Data, false)
 			case <-ctxW.Done():
 				s.networkStream = nil

--- a/network_node.go
+++ b/network_node.go
@@ -95,10 +95,10 @@ func constructDHTRouting(ctx context.Context, host host.Host, dstore ds.Batching
 	}
 	dhtRouting.Selector["v"] = func(_ string, bs [][]byte) (int, error) { return 0, nil }
 
-	if err := dhtRouting.Bootstrap(context.Background()); err != nil {
-		glog.Errorf("Error bootstraping dht: %v", err)
-		return nil, err
-	}
+	// if err := dhtRouting.Bootstrap(context.Background()); err != nil {
+	// 	glog.Errorf("Error bootstraping dht: %v", err)
+	// 	return nil, err
+	// }
 	return dhtRouting, nil
 }
 
@@ -131,6 +131,8 @@ func (n *NetworkNode) RefreshStream(pid peer.ID) *BasicStream {
 				err := streamHandler(n.Network, strm)
 				if err != nil {
 					glog.Errorf("Got error handling stream: %v", err)
+					n.Network.NetworkNode.RemoveStream(strm.Stream.Conn().RemotePeer())
+					strm.Stream.Close()
 					return
 				}
 			}


### PR DESCRIPTION
handleCancelReq had a bug (returning ErrProtocol when we weren't suppose to)

Also changed the network node to:
1. Fix bug of forgetting to remove a stream when an error occurs.
2. Remove the DHT bootstrapping logic, since we are not using the DHT anymore.  It's making random connections in the network (could be good, but I think there is a better way to do the bootstrapping)
