### PR TITLE
Uni-directional Streams

### DIFF
--- a/basic_broadcaster.go
+++ b/basic_broadcaster.go
@@ -59,6 +59,13 @@ func (b *BasicBroadcaster) Finish() error {
 	return nil
 }
 
+func (br *BasicBroadcaster) AddListener(nw *BasicVideoNetwork, pid peer.ID) {
+	key := peer.IDHexEncode(pid)
+	if _, ok := br.listeners[key]; !ok {
+		br.listeners[key] = nw.NetworkNode.GetStream(pid)
+	}
+}
+
 func (b *BasicBroadcaster) broadcastToListeners(ctx context.Context) {
 	for {
 		select {

--- a/basic_network.go
+++ b/basic_network.go
@@ -103,6 +103,10 @@ func (n *BasicVideoNetwork) GetBroadcaster(strmID string) (lpnet.Broadcaster, er
 	return b, nil
 }
 
+func (n *BasicVideoNetwork) SetBroadcaster(strmID string, b *BasicBroadcaster) {
+	n.broadcasters[strmID] = b
+}
+
 //GetSubscriber gets a subscriber for a streamID.  If it doesn't exist, create a new one.
 func (n *BasicVideoNetwork) GetSubscriber(strmID string) (lpnet.Subscriber, error) {
 	s, ok := n.subscribers[strmID]
@@ -112,6 +116,17 @@ func (n *BasicVideoNetwork) GetSubscriber(strmID string) (lpnet.Subscriber, erro
 		lpmon.Instance().LogSub(strmID)
 	}
 	return s, nil
+}
+
+func (n *BasicVideoNetwork) SetSubscriber(strmID string, s *BasicSubscriber) {
+	n.subscribers[strmID] = s
+}
+
+func (n *BasicVideoNetwork) getSubscriber(strmID string) *BasicSubscriber {
+	if s, ok := n.subscribers[strmID]; ok {
+		return s
+	}
+	return nil
 }
 
 //NewRelayer creates a new relayer.
@@ -299,6 +314,7 @@ func (n *BasicVideoNetwork) SetupProtocol() error {
 				stream.Reset()
 				return
 			}
+			glog.Infof("SetupProtocol: Done reading message...")
 		}
 	})
 
@@ -321,7 +337,7 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 			return ErrProtocol
 		}
 		glog.V(5).Infof("Got Sub Req: %v", sr)
-		return handleSubReq(nw, sr, ws)
+		return handleSubReq(nw, sr, ws.Stream.Conn().RemotePeer())
 	case CancelSubID:
 		cr, ok := msg.Data.(CancelSubMsg)
 		if !ok {
@@ -335,7 +351,7 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 		if !ok {
 			glog.Errorf("Cannot convert SubReqMsg: %v", msg.Data)
 		}
-		err := handleStreamData(nw, sd)
+		err := handleStreamData(nw, ws.Stream.Conn().RemotePeer(), sd)
 		if err == ErrProtocol {
 			glog.Errorf("Got protocol error, but ignoring it for now")
 			return nil
@@ -374,19 +390,20 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 	}
 }
 
-func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) error {
+func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, remotePID peer.ID) error {
 	glog.Infof("Handling sub req for %v", subReq.StrmID)
 	//If we have local broadcaster, just listen.
 	if b := nw.broadcasters[subReq.StrmID]; b != nil {
-		glog.V(5).Infof("Handling subReq, adding listener %v to broadcaster", peer.IDHexEncode(ws.Stream.Conn().RemotePeer()))
+		glog.V(5).Infof("Handling subReq, adding listener %v to broadcaster", peer.IDHexEncode(remotePID))
 		//TODO: Add verification code for the SubNodeID (Make sure the message is not spoofed)
-		remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
-		b.AddListener(nw, ws.Stream.Conn().RemotePeer())
+		// remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
+		b.AddListener(nw, remotePID)
 
 		//Send the last video chunk so we don't have to wait for the next one.
 		for _, msg := range b.lastMsgs {
 			if msg != nil {
-				b.sendDataMsg(remotePid, ws, msg)
+				glog.Infof("Sending last msg: %v", msg.SeqNo)
+				b.sendDataMsg(peer.IDHexEncode(remotePID), nw.NetworkNode.GetStream(remotePID), msg)
 				time.Sleep(DefaultBroadcasterBufferSegSendInterval)
 			}
 		}
@@ -395,17 +412,17 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 
 	//If we have a local relayer, add to the listener
 	if r := nw.relayers[relayerMapKey(subReq.StrmID, SubReqID)]; r != nil {
-		r.AddListener(nw, ws.Stream.Conn().RemotePeer())
+		r.AddListener(nw, remotePID)
 		return nil
 	}
 
 	//If we have a local subscriber (and not a relayer), create a relayer
 	if s := nw.subscribers[subReq.StrmID]; s != nil {
-		remotePeer := ws.Stream.Conn().RemotePeer()
+		// remotePeer := ws.Stream.Conn().RemotePeer()
 		r := nw.NewRelayer(subReq.StrmID, SubReqID)
 		r.UpstreamPeer = s.UpstreamPeer
-		lpmon.Instance().LogRelay(subReq.StrmID, peer.IDHexEncode(remotePeer))
-		r.AddListener(nw, ws.Stream.Conn().RemotePeer())
+		lpmon.Instance().LogRelay(subReq.StrmID, peer.IDHexEncode(remotePID))
+		r.AddListener(nw, remotePID)
 	}
 
 	//If we don't have local broadcaster, relayer, or a subscriber, forward the sub request to the closest peer
@@ -418,7 +435,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 	//Send Sub Req to the network
 	for _, p := range peers {
 		//Don't send it back to the requesting peer
-		if p == ws.Stream.Conn().RemotePeer() || p == nw.NetworkNode.Identity {
+		if p == remotePID || p == nw.NetworkNode.Identity {
 			continue
 		}
 
@@ -436,13 +453,13 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 			}
 
 			if r := nw.relayers[relayerMapKey(subReq.StrmID, SubReqID)]; r != nil {
-				r.AddListener(nw, ws.Stream.Conn().RemotePeer())
+				r.AddListener(nw, remotePID)
 			} else {
 				glog.V(common.VERBOSE).Infof("Creating relayer for sub req")
 				r := nw.NewRelayer(subReq.StrmID, SubReqID)
 				r.UpstreamPeer = p
 				lpmon.Instance().LogRelay(subReq.StrmID, peer.IDHexEncode(p))
-				r.AddListener(nw, ws.Stream.Conn().RemotePeer())
+				r.AddListener(nw, remotePID)
 			}
 			return nil
 		} else {
@@ -481,13 +498,13 @@ func handleCancelSubReq(nw *BasicVideoNetwork, cr CancelSubMsg, rpeer peer.ID) e
 		return nil
 	} else {
 		glog.Errorf("Cannot find broadcaster or relayer.  Error!")
-		return ErrProtocol
+		return nil //Cancel could be sent because of many reasons. (for example, Finish is sent, and at the same time, viewer cancels subscription) Let's not return an error for now.
 	}
 }
 
-func handleStreamData(nw *BasicVideoNetwork, sd StreamDataMsg) error {
+func handleStreamData(nw *BasicVideoNetwork, remotePID peer.ID, sd StreamDataMsg) error {
 	//A node can have a subscriber AND a relayer for the same stream.
-	s := nw.subscribers[sd.StrmID]
+	s := nw.getSubscriber(sd.StrmID)
 	if s != nil {
 		ctx, _ := context.WithTimeout(context.Background(), SubscriberDataInsertTimeout)
 		start := time.Now()
@@ -495,6 +512,10 @@ func handleStreamData(nw *BasicVideoNetwork, sd StreamDataMsg) error {
 			select {
 			case s.msgChan <- sd:
 				glog.V(4).Infof("Data segment %v for %v inserted. (%v)", sd.SeqNo, sd.StrmID, time.Since(start))
+				// if err := nw.NetworkNode.GetStream(remotePID).SendMessage(GetMasterPlaylistReqID, GetMasterPlaylistReqMsg{StrmID: sd.StrmID}); err != nil {
+				// 	glog.Errorf("Error sending test GetMasterPlaylistReq: %v", err)
+				// }
+				// glog.Infof("Done sending test GetMasterPlaylist Req")
 			case <-ctx.Done():
 				glog.Errorf("Subscriber data insert done for stream: %v - %v", sd.StrmID, ctx.Err())
 			}
@@ -521,8 +542,8 @@ func handleFinishStream(nw *BasicVideoNetwork, fs FinishStreamMsg) error {
 	//A node can have a subscriber AND a relayer for the same stream.
 	s := nw.subscribers[fs.StrmID]
 	if s != nil {
-		//Cancel subscriber worker, delete subscriber
-		s.cancelWorker()
+		//Unsubscribe, delete subscriber
+		s.Unsubscribe()
 		delete(nw.subscribers, fs.StrmID)
 	}
 

--- a/basic_network.go
+++ b/basic_network.go
@@ -280,11 +280,6 @@ func (n *BasicVideoNetwork) updateMasterPlaylistWithRelay(strmID string, mpl *m3
 }
 
 func (n *BasicVideoNetwork) updateMasterPlaylistWithDHT(strmID string, mpl *m3u8.MasterPlaylist) error {
-	// nid, err := extractNodeID(strmID)
-	// if err != nil {
-	// 	return err
-	// }
-	// if err := n.NetworkNode.Kad.PutValue(context.Background(), string([]byte(nid)), mpl.Encode().Bytes()); err != nil {
 	if err := n.NetworkNode.Kad.PutValue(context.Background(), fmt.Sprintf("/v/%v", strmID), mpl.Encode().Bytes()); err != nil {
 		glog.Errorf("Error putting playlist into DHT: %v", err)
 		return err
@@ -297,19 +292,11 @@ func (n *BasicVideoNetwork) SetupProtocol() error {
 	glog.V(4).Infof("\n\nSetting up protocol: %v", Protocol)
 	n.NetworkNode.PeerHost.SetStreamHandler(Protocol, func(stream net.Stream) {
 		ws := NewBasicStream(stream)
-		if _, ok := n.NetworkNode.streams[stream.Conn().RemotePeer()]; !ok {
-			n.NetworkNode.streams[stream.Conn().RemotePeer()] = ws
-		} else {
-			glog.Errorf("Protocol Error: already have the stream...")
-			stream.Close()
-			return
-		}
-
 		for {
 			if err := streamHandler(n, ws); err != nil {
 				glog.Errorf("Error handling stream: %v", err)
 				n.NetworkNode.RemoveStream(stream.Conn().RemotePeer())
-				stream.Close()
+				stream.Reset()
 				return
 			}
 		}
@@ -322,10 +309,6 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 	msg, err := ws.ReceiveMessage()
 	if err != nil {
 		glog.Errorf("Got error decoding msg from %v: %v (%v).", peer.IDHexEncode(ws.Stream.Conn().RemotePeer()), err, reflect.TypeOf(err))
-		// if err == multicodec.ErrMismatch {
-		// 	glog.Infof("Got multicoded error.  msg: %v", msg)
-		// 	return nil
-		// }
 		return err
 	}
 	// glog.V(4).Infof("%v Received a message %v from %v", peer.IDHexEncode(ws.Stream.Conn().LocalPeer()), msg.Op, peer.IDHexEncode(ws.Stream.Conn().RemotePeer()))
@@ -354,9 +337,6 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 		}
 		err := handleStreamData(nw, sd)
 		if err == ErrProtocol {
-			// if err := ws.SendMessage(CancelSubID, CancelSubMsg{StrmID: sd.StrmID}); err != nil {
-			// 	glog.Errorf("Error sending cancel msg")
-			// }
 			glog.Errorf("Got protocol error, but ignoring it for now")
 			return nil
 		} else {
@@ -373,14 +353,14 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 		if !ok {
 			glog.Errorf("Cannot convert TranscodeResponseMsg: %v", msg.Data)
 		}
-		return handleTranscodeResponse(nw, ws, tr)
+		return handleTranscodeResponse(nw, ws.Stream.Conn().RemotePeer(), tr)
 	case GetMasterPlaylistReqID:
 		//Get the local master playlist from a broadcaster and send it back
 		mplr, ok := msg.Data.(GetMasterPlaylistReqMsg)
 		if !ok {
 			glog.Errorf("Cannot convert GetMasterPlaylistReqMsg: %v", msg.Data)
 		}
-		return handleGetMasterPlaylistReq(nw, ws, mplr)
+		return handleGetMasterPlaylistReq(nw, ws.Stream.Conn().RemotePeer(), mplr)
 	case MasterPlaylistDataID:
 		mpld, ok := msg.Data.(MasterPlaylistDataMsg)
 		if !ok {
@@ -401,7 +381,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 		glog.V(5).Infof("Handling subReq, adding listener %v to broadcaster", peer.IDHexEncode(ws.Stream.Conn().RemotePeer()))
 		//TODO: Add verification code for the SubNodeID (Make sure the message is not spoofed)
 		remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
-		b.listeners[remotePid] = ws
+		b.AddListener(nw, ws.Stream.Conn().RemotePeer())
 
 		//Send the last video chunk so we don't have to wait for the next one.
 		for _, msg := range b.lastMsgs {
@@ -415,8 +395,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 
 	//If we have a local relayer, add to the listener
 	if r := nw.relayers[relayerMapKey(subReq.StrmID, SubReqID)]; r != nil {
-		remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
-		r.listeners[remotePid] = ws
+		r.AddListener(nw, ws.Stream.Conn().RemotePeer())
 		return nil
 	}
 
@@ -426,7 +405,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 		r := nw.NewRelayer(subReq.StrmID, SubReqID)
 		r.UpstreamPeer = s.UpstreamPeer
 		lpmon.Instance().LogRelay(subReq.StrmID, peer.IDHexEncode(remotePeer))
-		r.listeners[peer.IDHexEncode(remotePeer)] = ws
+		r.AddListener(nw, ws.Stream.Conn().RemotePeer())
 	}
 
 	//If we don't have local broadcaster, relayer, or a subscriber, forward the sub request to the closest peer
@@ -457,15 +436,13 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, ws *BasicStream) erro
 			}
 
 			if r := nw.relayers[relayerMapKey(subReq.StrmID, SubReqID)]; r != nil {
-				remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
-				r.listeners[remotePid] = ws
+				r.AddListener(nw, ws.Stream.Conn().RemotePeer())
 			} else {
 				glog.V(common.VERBOSE).Infof("Creating relayer for sub req")
 				r := nw.NewRelayer(subReq.StrmID, SubReqID)
 				r.UpstreamPeer = p
 				lpmon.Instance().LogRelay(subReq.StrmID, peer.IDHexEncode(p))
-				remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
-				r.listeners[remotePid] = ws
+				r.AddListener(nw, ws.Stream.Conn().RemotePeer())
 			}
 			return nil
 		} else {
@@ -526,6 +503,7 @@ func handleStreamData(nw *BasicVideoNetwork, sd StreamDataMsg) error {
 
 	r := nw.relayers[relayerMapKey(sd.StrmID, SubReqID)]
 	if r != nil {
+		glog.Infof("relaying stream data: %v:%v", sd.StrmID, sd.SeqNo)
 		if err := r.RelayStreamData(sd); err != nil {
 			glog.Errorf("Error relaying stream data: %v", err)
 			return err
@@ -564,7 +542,7 @@ func handleFinishStream(nw *BasicVideoNetwork, fs FinishStreamMsg) error {
 	return nil
 }
 
-func handleTranscodeResponse(nw *BasicVideoNetwork, ws *BasicStream, tr TranscodeResponseMsg) error {
+func handleTranscodeResponse(nw *BasicVideoNetwork, remotePID peer.ID, tr TranscodeResponseMsg) error {
 	glog.V(5).Infof("Transcode Result StreamIDs: %v", tr)
 	callback, ok := nw.transResponseCallbacks[tr.StrmID]
 	if ok {
@@ -580,7 +558,7 @@ func handleTranscodeResponse(nw *BasicVideoNetwork, ws *BasicStream, tr Transcod
 	dupCount := DefaultTranscodeResponseRelayDuplication
 	for _, p := range peers {
 		//Don't send it back to the requesting peer
-		if p == ws.Stream.Conn().RemotePeer() || p == nw.NetworkNode.Identity {
+		if p == remotePID || p == nw.NetworkNode.Identity {
 			continue
 		}
 
@@ -606,17 +584,17 @@ func handleTranscodeResponse(nw *BasicVideoNetwork, ws *BasicStream, tr Transcod
 	return nil
 }
 
-func handleGetMasterPlaylistReq(nw *BasicVideoNetwork, ws *BasicStream, mplr GetMasterPlaylistReqMsg) error {
+func handleGetMasterPlaylistReq(nw *BasicVideoNetwork, remotePID peer.ID, mplr GetMasterPlaylistReqMsg) error {
 	mpl, ok := nw.mplMap[mplr.StrmID]
 	if !ok {
 		//Don't have the playlist locally. Forward to a peer
 		peers, err := closestLocalPeers(nw.NetworkNode.PeerHost.Peerstore(), mplr.StrmID)
 		if err != nil {
-			return ws.SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, NotFound: true})
+			return nw.NetworkNode.GetStream(remotePID).SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, NotFound: true})
 		}
 		for _, p := range peers {
 			//Don't send it back to the requesting peer
-			if p == ws.Stream.Conn().RemotePeer() || p == nw.NetworkNode.Identity {
+			if p == remotePID || p == nw.NetworkNode.Identity {
 				continue
 			}
 
@@ -639,16 +617,15 @@ func handleGetMasterPlaylistReq(nw *BasicVideoNetwork, ws *BasicStream, mplr Get
 					r.UpstreamPeer = p
 					lpmon.Instance().LogRelay(mplr.StrmID, peer.IDHexEncode(p))
 				}
-				remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
-				r.listeners[remotePid] = ws
+				r.AddListener(nw, remotePID)
 				return nil
 			}
 		}
 		glog.Info("Cannot relay GetMasterPlaylist req to peers")
-		return ws.SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, NotFound: true})
+		return nw.NetworkNode.GetStream(remotePID).SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, NotFound: true})
 	}
 
-	return ws.SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, MPL: mpl.String()})
+	return nw.NetworkNode.GetStream(remotePID).SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, MPL: mpl.String()})
 }
 
 func handleMasterPlaylistDataMsg(nw *BasicVideoNetwork, mpld MasterPlaylistDataMsg) error {

--- a/basic_network.go
+++ b/basic_network.go
@@ -314,7 +314,6 @@ func (n *BasicVideoNetwork) SetupProtocol() error {
 				stream.Reset()
 				return
 			}
-			glog.Infof("SetupProtocol: Done reading message...")
 		}
 	})
 
@@ -396,13 +395,12 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, remotePID peer.ID) er
 	if b := nw.broadcasters[subReq.StrmID]; b != nil {
 		glog.V(5).Infof("Handling subReq, adding listener %v to broadcaster", peer.IDHexEncode(remotePID))
 		//TODO: Add verification code for the SubNodeID (Make sure the message is not spoofed)
-		// remotePid := peer.IDHexEncode(ws.Stream.Conn().RemotePeer())
 		b.AddListener(nw, remotePID)
 
 		//Send the last video chunk so we don't have to wait for the next one.
 		for _, msg := range b.lastMsgs {
 			if msg != nil {
-				glog.Infof("Sending last msg: %v", msg.SeqNo)
+				// glog.Infof("Sending last msg: %v", msg.SeqNo)
 				b.sendDataMsg(peer.IDHexEncode(remotePID), nw.NetworkNode.GetStream(remotePID), msg)
 				time.Sleep(DefaultBroadcasterBufferSegSendInterval)
 			}
@@ -418,7 +416,6 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, remotePID peer.ID) er
 
 	//If we have a local subscriber (and not a relayer), create a relayer
 	if s := nw.subscribers[subReq.StrmID]; s != nil {
-		// remotePeer := ws.Stream.Conn().RemotePeer()
 		r := nw.NewRelayer(subReq.StrmID, SubReqID)
 		r.UpstreamPeer = s.UpstreamPeer
 		lpmon.Instance().LogRelay(subReq.StrmID, peer.IDHexEncode(remotePID))
@@ -512,10 +509,6 @@ func handleStreamData(nw *BasicVideoNetwork, remotePID peer.ID, sd StreamDataMsg
 			select {
 			case s.msgChan <- sd:
 				glog.V(4).Infof("Data segment %v for %v inserted. (%v)", sd.SeqNo, sd.StrmID, time.Since(start))
-				// if err := nw.NetworkNode.GetStream(remotePID).SendMessage(GetMasterPlaylistReqID, GetMasterPlaylistReqMsg{StrmID: sd.StrmID}); err != nil {
-				// 	glog.Errorf("Error sending test GetMasterPlaylistReq: %v", err)
-				// }
-				// glog.Infof("Done sending test GetMasterPlaylist Req")
 			case <-ctx.Done():
 				glog.Errorf("Subscriber data insert done for stream: %v - %v", sd.StrmID, ctx.Err())
 			}
@@ -524,7 +517,6 @@ func handleStreamData(nw *BasicVideoNetwork, remotePID peer.ID, sd StreamDataMsg
 
 	r := nw.relayers[relayerMapKey(sd.StrmID, SubReqID)]
 	if r != nil {
-		glog.Infof("relaying stream data: %v:%v", sd.StrmID, sd.SeqNo)
 		if err := r.RelayStreamData(sd); err != nil {
 			glog.Errorf("Error relaying stream data: %v", err)
 			return err

--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -926,7 +926,6 @@ func TestSendTranscodeResponse(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error sending transcode result: %v", err)
 	}
-	timer := time.NewTimer(time.Second * 3)
 	select {
 	case r := <-rc:
 		if r["strmid1"] != lpms.P240p30fps4x3.Name {
@@ -935,7 +934,7 @@ func TestSendTranscodeResponse(t *testing.T) {
 		if r["strmid2"] != lpms.P360p30fps4x3.Name {
 			t.Errorf("Expecting %v, got %v", lpms.P360p30fps4x3.Name, r["strmid2"])
 		}
-	case <-timer.C:
+	case <-time.After(time.Second * 5):
 		t.Errorf("Timed out")
 	}
 
@@ -1228,7 +1227,6 @@ func TestMasterPlaylistIntegration(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting master playlist: %v", err)
 	}
-	timer = time.NewTimer(time.Second * 3)
 	select {
 	case r := <-mplc:
 		vars := r.Variants
@@ -1241,7 +1239,7 @@ func TestMasterPlaylistIntegration(t *testing.T) {
 		if len(n2.relayers) != 1 {
 			t.Errorf("Expecting 1 relayer in n2")
 		}
-	case <-timer.C:
+	case <-time.After(time.Second * 5):
 		t.Errorf("Timed out")
 	}
 }

--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -19,7 +19,6 @@ import (
 	host "gx/ipfs/Qmc1XhrFEiSeBNn3mpfg6gEuYCt5im2gYmNVmncsvmpeAk/go-libp2p-host"
 
 	"github.com/ericxtang/m3u8"
-	common "github.com/livepeer/go-livepeer/common"
 	lpms "github.com/livepeer/lpms/core"
 
 	"github.com/golang/glog"
@@ -597,9 +596,16 @@ func TestSendSubscribe(t *testing.T) {
 		t.Errorf("Subscriber should be working")
 	}
 
-	common.WaitAssert(t, time.Second*1, func() bool {
-		return len(result) == 10
-	}, fmt.Sprintf("Expecting length of result to be 10, but got %v: %v", len(result), result))
+	for start := time.Now(); time.Since(start) < 1*time.Second; {
+		if len(result) == 10 {
+			break
+		} else {
+			time.Sleep(time.Millisecond * 50)
+		}
+	}
+	if len(result) != 10 {
+		t.Errorf("Expecting length of result to be 10, but got %v: %v", len(result), result)
+	}
 
 	for _, d := range result {
 		if string(d) != "test data" {
@@ -610,9 +616,16 @@ func TestSendSubscribe(t *testing.T) {
 	//Call cancel
 	s1.cancelWorker()
 
-	common.WaitAssert(t, time.Second*1, func() bool {
-		return cancelMsg.StrmID != ""
-	}, fmt.Sprintf("Expecting to get cancelMsg with StrmID: 'strmID', but got %v", cancelMsg.StrmID))
+	for start := time.Now(); time.Since(start) < 1*time.Second; {
+		if cancelMsg.StrmID != "" {
+			break
+		} else {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	if cancelMsg.StrmID != "" {
+		t.Errorf("Expecting to get cancelMsg with StrmID: 'strmID', but got %v", cancelMsg.StrmID)
+	}
 
 	if s1.working {
 		t.Errorf("subscriber shouldn't be working after 'cancel' is called")

--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -623,8 +623,8 @@ func TestSendSubscribe(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 		}
 	}
-	if cancelMsg.StrmID != "" {
-		t.Errorf("Expecting to get cancelMsg with StrmID: 'strmID', but got %v", cancelMsg.StrmID)
+	if cancelMsg.StrmID != strmID {
+		t.Errorf("Expecting to get cancelMsg with StrmID: %v, but got %v", strmID, cancelMsg.StrmID)
 	}
 
 	if s1.working {

--- a/basic_relayer.go
+++ b/basic_relayer.go
@@ -21,7 +21,7 @@ type BasicRelayer struct {
 func (br *BasicRelayer) RelayStreamData(sd StreamDataMsg) error {
 	for strmID, l := range br.listeners {
 		// glog.V(5).Infof("Relaying stream data to listener: %v", l)
-		glog.Infof("Relaying stream data to listener: %v", peer.IDHexEncode(l.Stream.Conn().RemotePeer()))
+		// glog.Infof("Relaying stream data to listener: %v", peer.IDHexEncode(l.Stream.Conn().RemotePeer()))
 		if err := l.SendMessage(StreamDataID, sd); err != nil {
 			glog.Errorf("Error writing data to relayer listener %v: %v", l, err)
 			delete(br.listeners, strmID)

--- a/basic_relayer.go
+++ b/basic_relayer.go
@@ -20,7 +20,8 @@ type BasicRelayer struct {
 //RelayStreamData sends a StreamDataMsg to its listeners
 func (br *BasicRelayer) RelayStreamData(sd StreamDataMsg) error {
 	for strmID, l := range br.listeners {
-		glog.V(5).Infof("Relaying stream data to listener: %v", l)
+		// glog.V(5).Infof("Relaying stream data to listener: %v", l)
+		glog.Infof("Relaying stream data to listener: %v", peer.IDHexEncode(l.Stream.Conn().RemotePeer()))
 		if err := l.SendMessage(StreamDataID, sd); err != nil {
 			glog.Errorf("Error writing data to relayer listener %v: %v", l, err)
 			delete(br.listeners, strmID)
@@ -50,6 +51,13 @@ func (br *BasicRelayer) RelayMasterPlaylistData(nw *BasicVideoNetwork, mpld Mast
 		br.LastRelay = time.Now()
 	}
 	return nil
+}
+
+func (br *BasicRelayer) AddListener(nw *BasicVideoNetwork, pid peer.ID) {
+	key := peer.IDHexEncode(pid)
+	if _, ok := br.listeners[key]; !ok {
+		br.listeners[key] = nw.NetworkNode.GetStream(pid)
+	}
 }
 
 func (br BasicRelayer) String() string {

--- a/basic_stream.go
+++ b/basic_stream.go
@@ -10,7 +10,6 @@ import (
 	net "gx/ipfs/QmNa31VPzC561NWwRsJLE7nGYZYuuD2QfpK2b1q9BK54J1/go-libp2p-net"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 
-	"github.com/livepeer/go-livepeer/common"
 	multicodec "github.com/multiformats/go-multicodec"
 	mcjson "github.com/multiformats/go-multicodec/json"
 
@@ -66,10 +65,10 @@ func (bs *BasicStream) ReceiveMessage() (Msg, error) {
 
 //SendMessage writes a message into the stream.
 func (bs *BasicStream) SendMessage(opCode Opcode, data interface{}) error {
-	glog.V(common.DEBUG).Infof("Sending msg %v to %v", opCode, peer.IDHexEncode(bs.Stream.Conn().RemotePeer()))
-	bs.el.Lock()
-	defer bs.el.Unlock()
+	// glog.V(common.DEBUG).Infof("Sending msg %v to %v", opCode, peer.IDHexEncode(bs.Stream.Conn().RemotePeer()))
+	glog.Infof("Locking stream to %v for send %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), opCode)
 	msg := Msg{Op: opCode, Data: data}
+	glog.Infof("Sending msg %v to %v", opCode, peer.IDHexEncode(bs.Stream.Conn().RemotePeer()))
 	return bs.encodeAndFlush(msg)
 }
 
@@ -78,6 +77,8 @@ func (bs *BasicStream) encodeAndFlush(n interface{}) error {
 	if bs == nil {
 		fmt.Println("stream is nil")
 	}
+
+	bs.el.Lock()
 	err := bs.enc.Encode(n)
 	if err != nil {
 		glog.Errorf("send message encode error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
@@ -89,6 +90,7 @@ func (bs *BasicStream) encodeAndFlush(n interface{}) error {
 		glog.Errorf("send message flush error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
 		return ErrStream
 	}
+	bs.el.Unlock()
 
 	return nil
 }

--- a/basic_stream.go
+++ b/basic_stream.go
@@ -66,9 +66,7 @@ func (bs *BasicStream) ReceiveMessage() (Msg, error) {
 //SendMessage writes a message into the stream.
 func (bs *BasicStream) SendMessage(opCode Opcode, data interface{}) error {
 	// glog.V(common.DEBUG).Infof("Sending msg %v to %v", opCode, peer.IDHexEncode(bs.Stream.Conn().RemotePeer()))
-	glog.Infof("Locking stream to %v for send %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), opCode)
 	msg := Msg{Op: opCode, Data: data}
-	glog.Infof("Sending msg %v to %v", opCode, peer.IDHexEncode(bs.Stream.Conn().RemotePeer()))
 	return bs.encodeAndFlush(msg)
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
     - go get -u github.com/whyrusleeping/gx-go
     - go get github.com/multiformats/go-multicodec
     - go get github.com/jbenet/go-msgio
+    - go get github.com/livepeer/go-livepeer/cmd/livepeer
     - go get github.com/livepeer/go-livepeer-basicnet
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull

--- a/circle.yml
+++ b/circle.yml
@@ -8,13 +8,12 @@ dependencies:
   override:
     - go get -u github.com/whyrusleeping/gx
     - go get -u github.com/whyrusleeping/gx-go
-    - go get github.com/multiformats/go-multicodec
-    - go get github.com/jbenet/go-msgio
-    - go get github.com/livepeer/go-livepeer/cmd/livepeer
+    # - go get github.com/multiformats/go-multicodec
+    # - go get github.com/jbenet/go-msgio
     - go get github.com/livepeer/go-livepeer-basicnet
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install
-    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull
+    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && rm -rf vendor && go get ./...
 
 test:
   override:
-    - cd "$HOME/go-livepeer-basicnet" && go test
+    - cd "$HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet" && git fetch && git checkout $CIRCLE_BRANCH && git pull && go test

--- a/circle.yml
+++ b/circle.yml
@@ -8,11 +8,10 @@ dependencies:
   override:
     - go get -u github.com/whyrusleeping/gx
     - go get -u github.com/whyrusleeping/gx-go
-    # - go get github.com/multiformats/go-multicodec
-    # - go get github.com/jbenet/go-msgio
+    - go get github.com/livepeer/lpms
+    - go get github.com/nareix/joy4
     - gx-go get github.com/livepeer/go-livepeer-basicnet
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install
-    # - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull && rm -rf vendor/github.com && go get ./...
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
     # - go get github.com/jbenet/go-msgio
     - gx-go get github.com/livepeer/go-livepeer-basicnet
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install
-    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && rm -rf vendor && go get ./...
+    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull && rm -rf vendor && go get ./...
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
     - go get -u github.com/whyrusleeping/gx-go
     # - go get github.com/multiformats/go-multicodec
     # - go get github.com/jbenet/go-msgio
-    - go get github.com/livepeer/go-livepeer-basicnet
+    - gx-go get github.com/livepeer/go-livepeer-basicnet
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && rm -rf vendor && go get ./...
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,9 +10,8 @@ dependencies:
     - go get -u github.com/whyrusleeping/gx-go
     - go get github.com/multiformats/go-multicodec
     - go get github.com/jbenet/go-msgio
-    - cd $HOME/go-livepeer-basicnet
-    - gx install
     - go get github.com/livepeer/go-livepeer-basicnet
+    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
   override:
     - go get -u github.com/whyrusleeping/gx
     - go get -u github.com/whyrusleeping/gx-go
-    - go get github.com/livepeer/lpms
+    - go get -d github.com/livepeer/lpms/cmd/example
     - go get github.com/nareix/joy4
     - gx-go get github.com/livepeer/go-livepeer-basicnet
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ dependencies:
     # - go get github.com/jbenet/go-msgio
     - gx-go get github.com/livepeer/go-livepeer-basicnet
     - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet && gx install
-    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull && rm -rf vendor && go get ./...
+    # - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull && rm -rf vendor/github.com && go get ./...
 
 test:
   override:
-    - cd "$HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet" && git fetch && git checkout $CIRCLE_BRANCH && git pull && go test
+    - cd "$HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet" && git fetch && git checkout $CIRCLE_BRANCH && git pull && gx-go get github.com/livepeer/go-livepeer-basicnet && go test

--- a/data.go
+++ b/data.go
@@ -114,11 +114,6 @@ func (m Msg) MarshalJSON() ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Failed to marshal GetMasterPlaylistReqMsg: %v", err)
 		}
-	case string:
-		err := enc.Encode(m.Data)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to marshal string: %v", err)
-		}
 	default:
 		return nil, errors.New("failed to marshal message data")
 	}
@@ -188,14 +183,6 @@ func (m *Msg) UnmarshalJSON(b []byte) error {
 			return errors.New("failed to decode GetMasterPlaylistReqMsg")
 		}
 		m.Data = mplr
-	case SimpleString:
-		var str string
-		err := dec.Decode(&str)
-		if err != nil {
-			return errors.New("Failed to decode string msg")
-		}
-		m.Data = str
-
 	default:
 		return errors.New("failed to decode message data")
 	}

--- a/network_node.go
+++ b/network_node.go
@@ -119,7 +119,7 @@ func (n *NetworkNode) RefreshStream(pid peer.ID) *BasicStream {
 	}
 
 	ns, err := n.PeerHost.NewStream(context.Background(), pid, Protocol)
-	glog.Infof("Making new stream to: %v", peer.IDHexEncode(pid))
+	// glog.Infof("Making new stream to: %v", peer.IDHexEncode(pid))
 	if err != nil {
 		glog.Errorf("%v Error creating stream to %v: %v", peer.IDHexEncode(n.Identity), peer.IDHexEncode(pid), err)
 		return nil

--- a/network_node.go
+++ b/network_node.go
@@ -21,11 +21,11 @@ import (
 )
 
 type NetworkNode struct {
-	Identity peer.ID // the local node's identity
-	Kad      *kad.IpfsDHT
-	PeerHost host.Host // the network host (server+client)
-	Network  *BasicVideoNetwork
-	streams  map[peer.ID]*BasicStream
+	Identity   peer.ID // the local node's identity
+	Kad        *kad.IpfsDHT
+	PeerHost   host.Host // the network host (server+client)
+	Network    *BasicVideoNetwork
+	outStreams map[peer.ID]*BasicStream
 }
 
 //NewNode creates a new Livepeerd node.
@@ -76,7 +76,7 @@ func NewNode(listenPort int, priv crypto.PrivKey, pub crypto.PubKey, f *BasicNot
 	rHost := rhost.Wrap(basicHost, dht)
 
 	glog.V(2).Infof("Created node: %v at %v", peer.IDHexEncode(rHost.ID()), rHost.Addrs())
-	nn := &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, streams: streams}
+	nn := &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, outStreams: streams}
 	f.HandleDisconnect(func(pid peer.ID) {
 		nn.RemoveStream(pid)
 	})
@@ -103,7 +103,7 @@ func constructDHTRouting(ctx context.Context, host host.Host, dstore ds.Batching
 }
 
 func (n *NetworkNode) GetStream(pid peer.ID) *BasicStream {
-	strm, ok := n.streams[pid]
+	strm, ok := n.outStreams[pid]
 	if !ok {
 		strm = n.RefreshStream(pid)
 	}
@@ -112,8 +112,8 @@ func (n *NetworkNode) GetStream(pid peer.ID) *BasicStream {
 
 func (n *NetworkNode) RefreshStream(pid peer.ID) *BasicStream {
 	// glog.Infof("Creating stream from %v to %v", peer.IDHexEncode(n.Identity), peer.IDHexEncode(pid))
-	if s, ok := n.streams[pid]; ok {
-		s.Stream.Close()
+	if s, ok := n.outStreams[pid]; ok {
+		s.Stream.Reset()
 	}
 
 	ns, err := n.PeerHost.NewStream(context.Background(), pid, Protocol)
@@ -122,27 +122,11 @@ func (n *NetworkNode) RefreshStream(pid peer.ID) *BasicStream {
 		return nil
 	}
 	strm := NewBasicStream(ns)
-	n.streams[pid] = strm
-
-	//Handle messages that come back from the stream.  Only do this if we are setting up the Livepeer network protocol.
-	if n.Network != nil {
-		go func() {
-			for {
-				err := streamHandler(n.Network, strm)
-				if err != nil {
-					glog.Errorf("Got error handling stream: %v", err)
-					n.Network.NetworkNode.RemoveStream(strm.Stream.Conn().RemotePeer())
-					strm.Stream.Close()
-					return
-				}
-			}
-		}()
-	}
-
+	n.outStreams[pid] = strm
 	return strm
 }
 
 func (n *NetworkNode) RemoveStream(pid peer.ID) {
 	// glog.Infof("Removing stream for %v", peer.IDHexEncode(pid))
-	delete(n.streams, pid)
+	delete(n.outStreams, pid)
 }

--- a/network_node.go
+++ b/network_node.go
@@ -3,6 +3,7 @@ package basicnet
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/golang/glog"
 
@@ -21,11 +22,12 @@ import (
 )
 
 type NetworkNode struct {
-	Identity   peer.ID // the local node's identity
-	Kad        *kad.IpfsDHT
-	PeerHost   host.Host // the network host (server+client)
-	Network    *BasicVideoNetwork
-	outStreams map[peer.ID]*BasicStream
+	Identity       peer.ID // the local node's identity
+	Kad            *kad.IpfsDHT
+	PeerHost       host.Host // the network host (server+client)
+	Network        *BasicVideoNetwork
+	outStreams     map[peer.ID]*BasicStream
+	outStreamsLock *sync.RWMutex
 }
 
 //NewNode creates a new Livepeerd node.
@@ -76,7 +78,7 @@ func NewNode(listenPort int, priv crypto.PrivKey, pub crypto.PubKey, f *BasicNot
 	rHost := rhost.Wrap(basicHost, dht)
 
 	glog.V(2).Infof("Created node: %v at %v", peer.IDHexEncode(rHost.ID()), rHost.Addrs())
-	nn := &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, outStreams: streams}
+	nn := &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, outStreams: streams, outStreamsLock: &sync.RWMutex{}}
 	f.HandleDisconnect(func(pid peer.ID) {
 		nn.RemoveStream(pid)
 	})
@@ -117,16 +119,21 @@ func (n *NetworkNode) RefreshStream(pid peer.ID) *BasicStream {
 	}
 
 	ns, err := n.PeerHost.NewStream(context.Background(), pid, Protocol)
+	glog.Infof("Making new stream to: %v", peer.IDHexEncode(pid))
 	if err != nil {
 		glog.Errorf("%v Error creating stream to %v: %v", peer.IDHexEncode(n.Identity), peer.IDHexEncode(pid), err)
 		return nil
 	}
 	strm := NewBasicStream(ns)
+	n.outStreamsLock.Lock()
 	n.outStreams[pid] = strm
+	n.outStreamsLock.Unlock()
 	return strm
 }
 
 func (n *NetworkNode) RemoveStream(pid peer.ID) {
 	// glog.Infof("Removing stream for %v", peer.IDHexEncode(pid))
+	n.outStreamsLock.Lock()
 	delete(n.outStreams, pid)
+	n.outStreamsLock.Unlock()
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
       "hash": "QmSAFA8v42u4gpJNy1tb7vW3JiiXiaYDC2b845c2RnNSJL",
       "name": "go-libp2p-kbucket",
       "version": "2.1.13"
+    },
+    {
+      "hash": "QmQGX417WoxKxDJeHqouMEmmH4G1RCENNSzkZYHrXy3Xb3",
+      "name": "go-libp2p-netutil",
+      "version": "0.3.4"
     }
   ],
   "gxVersion": "0.11.0",


### PR DESCRIPTION
Changes due to @whyrusleeping's suggestion.  We now only maintain a reference to streams going out.  For streams coming in, we just keep it in a for loop until it errors out.

Fixes issue: https://github.com/livepeer/go-livepeer/issues/194, https://github.com/livepeer/go-livepeer/issues/190