### PR TITLE
Change error handling, Remove deadlock

### DIFF
--- a/basic_network.go
+++ b/basic_network.go
@@ -433,7 +433,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, remotePID peer.ID) er
 	peers, err := closestLocalPeers(nw.NetworkNode.PeerHost.Peerstore(), subReq.StrmID)
 	if err != nil {
 		glog.Errorf("Error getting closest local node: %v", err)
-		return nil
+		return ErrHandleMsg
 	}
 
 	//Send Sub Req to the network

--- a/basic_network.go
+++ b/basic_network.go
@@ -33,9 +33,9 @@ var Protocol = protocol.ID("/livepeer_video/0.0.1")
 var ErrNoClosePeers = errors.New("NoClosePeers")
 var ErrUnknownMsg = errors.New("UnknownMsgType")
 var ErrProtocol = errors.New("ProtocolError")
+var ErrHandleMsg = errors.New("ErrHandleMsg")
 var ErrTranscodeResponse = errors.New("TranscodeResponseError")
 var ErrGetMasterPlaylist = errors.New("ErrGetMasterPlaylist")
-var ErrHandleMasterPlaylist = errors.New("ErrHandleMaterPlaylist")
 var GetMasterPlaylistRelayWait = 10 * time.Second
 
 const RelayGCTime = 60 * time.Second
@@ -309,10 +309,12 @@ func (n *BasicVideoNetwork) SetupProtocol() error {
 		ws := NewBasicStream(stream)
 		for {
 			if err := streamHandler(n, ws); err != nil {
-				glog.Errorf("Error handling stream: %v", err)
-				n.NetworkNode.RemoveStream(stream.Conn().RemotePeer())
-				stream.Reset()
-				return
+				if err != ErrHandleMsg {
+					glog.Errorf("Error handling stream: %v", err)
+					n.NetworkNode.RemoveStream(stream.Conn().RemotePeer())
+					stream.Reset()
+					return
+				}
 			}
 		}
 	})
@@ -349,6 +351,7 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 		sd, ok := msg.Data.(StreamDataMsg)
 		if !ok {
 			glog.Errorf("Cannot convert SubReqMsg: %v", msg.Data)
+			return ErrProtocol
 		}
 		err := handleStreamData(nw, ws.Stream.Conn().RemotePeer(), sd)
 		if err == ErrProtocol {
@@ -361,12 +364,14 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 		fs, ok := msg.Data.(FinishStreamMsg)
 		if !ok {
 			glog.Errorf("Cannot convert FinishStreamMsg: %v", msg.Data)
+			return ErrProtocol
 		}
 		return handleFinishStream(nw, fs)
 	case TranscodeResponseID:
 		tr, ok := msg.Data.(TranscodeResponseMsg)
 		if !ok {
 			glog.Errorf("Cannot convert TranscodeResponseMsg: %v", msg.Data)
+			return ErrProtocol
 		}
 		return handleTranscodeResponse(nw, ws.Stream.Conn().RemotePeer(), tr)
 	case GetMasterPlaylistReqID:
@@ -374,12 +379,14 @@ func streamHandler(nw *BasicVideoNetwork, ws *BasicStream) error {
 		mplr, ok := msg.Data.(GetMasterPlaylistReqMsg)
 		if !ok {
 			glog.Errorf("Cannot convert GetMasterPlaylistReqMsg: %v", msg.Data)
+			return ErrProtocol
 		}
 		return handleGetMasterPlaylistReq(nw, ws.Stream.Conn().RemotePeer(), mplr)
 	case MasterPlaylistDataID:
 		mpld, ok := msg.Data.(MasterPlaylistDataMsg)
 		if !ok {
 			glog.Errorf("Cannot convert MasterPlaylistDataMsg: %v", msg.Data)
+			return ErrProtocol
 		}
 		return handleMasterPlaylistDataMsg(nw, mpld)
 	default:
@@ -426,7 +433,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, remotePID peer.ID) er
 	peers, err := closestLocalPeers(nw.NetworkNode.PeerHost.Peerstore(), subReq.StrmID)
 	if err != nil {
 		glog.Errorf("Error getting closest local node: %v", err)
-		return err
+		return nil
 	}
 
 	//Send Sub Req to the network
@@ -465,7 +472,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, remotePID peer.ID) er
 	}
 
 	glog.Errorf("%v Cannot forward Sub req to any of the peers: %v", nw.GetNodeID(), peers)
-	return ErrProtocol
+	return ErrHandleMsg
 }
 
 func handleCancelSubReq(nw *BasicVideoNetwork, cr CancelSubMsg, rpeer peer.ID) error {
@@ -519,13 +526,13 @@ func handleStreamData(nw *BasicVideoNetwork, remotePID peer.ID, sd StreamDataMsg
 	if r != nil {
 		if err := r.RelayStreamData(sd); err != nil {
 			glog.Errorf("Error relaying stream data: %v", err)
-			return err
+			return ErrHandleMsg
 		}
 	}
 
 	if s == nil && r == nil {
 		glog.Errorf("Something is wrong.  Expect subscriber or relayer for seg:%v strm:%v to exist at this point (should have been setup when SubReq came in)", sd.SeqNo, sd.StrmID)
-		return ErrProtocol
+		return ErrHandleMsg
 	}
 	return nil
 }
@@ -550,7 +557,7 @@ func handleFinishStream(nw *BasicVideoNetwork, fs FinishStreamMsg) error {
 
 	if s == nil && r == nil {
 		glog.Errorf("Error: cannot find subscriber or relayer")
-		return ErrProtocol
+		return ErrHandleMsg
 	}
 	return nil
 }
@@ -583,7 +590,10 @@ func handleTranscodeResponse(nw *BasicVideoNetwork, remotePID peer.ID, tr Transc
 		s := nw.NetworkNode.GetStream(p)
 		if s != nil {
 			if err := s.SendMessage(TranscodeResponseID, tr); err != nil {
+				glog.Errorf("Error sending Transcoding Response Message to %v", peer.IDHexEncode(p))
 				continue
+			} else {
+				return nil
 			}
 
 			//Don't need to set up a relayer here because we don't expect any response.
@@ -594,7 +604,7 @@ func handleTranscodeResponse(nw *BasicVideoNetwork, remotePID peer.ID, tr Transc
 		dupCount--
 	}
 	glog.Info("Cannot relay TranscodeResponse to peers")
-	return nil
+	return ErrHandleMsg
 }
 
 func handleGetMasterPlaylistReq(nw *BasicVideoNetwork, remotePID peer.ID, mplr GetMasterPlaylistReqMsg) error {
@@ -635,10 +645,18 @@ func handleGetMasterPlaylistReq(nw *BasicVideoNetwork, remotePID peer.ID, mplr G
 			}
 		}
 		glog.Info("Cannot relay GetMasterPlaylist req to peers")
-		return nw.NetworkNode.GetStream(remotePID).SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, NotFound: true})
+		if err := nw.NetworkNode.GetStream(remotePID).SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, NotFound: true}); err != nil {
+			glog.Errorf("Error sending MasterPlaylistData-NotFound: %v", err)
+			return ErrHandleMsg
+		}
+		return nil
 	}
 
-	return nw.NetworkNode.GetStream(remotePID).SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, MPL: mpl.String()})
+	if err := nw.NetworkNode.GetStream(remotePID).SendMessage(MasterPlaylistDataID, MasterPlaylistDataMsg{StrmID: mplr.StrmID, MPL: mpl.String()}); err != nil {
+		glog.Errorf("Error sending MasterPlaylistData: %v", err)
+		return ErrHandleMsg
+	}
+	return nil
 }
 
 func handleMasterPlaylistDataMsg(nw *BasicVideoNetwork, mpld MasterPlaylistDataMsg) error {
@@ -650,7 +668,7 @@ func handleMasterPlaylistDataMsg(nw *BasicVideoNetwork, mpld MasterPlaylistDataM
 			return r.RelayMasterPlaylistData(nw, mpld)
 		} else {
 			glog.Errorf("Got master playlist data, but don't have a channel")
-			return ErrHandleMasterPlaylist
+			return ErrHandleMsg
 		}
 	}
 
@@ -663,7 +681,7 @@ func handleMasterPlaylistDataMsg(nw *BasicVideoNetwork, mpld MasterPlaylistDataM
 	mpl := m3u8.NewMasterPlaylist()
 	if err := mpl.DecodeFrom(strings.NewReader(mpld.MPL), true); err != nil {
 		glog.Errorf("Error decoding playlist: %v", err)
-		return ErrGetMasterPlaylist
+		return ErrHandleMsg
 	}
 
 	//insert into channel

--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -31,14 +31,20 @@ func init() {
 	// flag.Lookup("v").Value.Set(logLevel)
 }
 
-func setupNodes(p1, p2 int) (*BasicVideoNetwork, *BasicVideoNetwork) {
+func setupNodes(t *testing.T, p1, p2 int) (*BasicVideoNetwork, *BasicVideoNetwork) {
 	priv1, pub1, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
 	no1, _ := NewNode(p1, priv1, pub1, &BasicNotifiee{})
 	n1, _ := NewBasicVideoNetwork(no1)
+	if err := n1.SetupProtocol(); err != nil {
+		t.Errorf("Error creating node: %v", err)
+	}
 
 	priv2, pub2, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
 	no2, _ := NewNode(p2, priv2, pub2, &BasicNotifiee{})
 	n2, _ := NewBasicVideoNetwork(no2)
+	if err := n2.SetupProtocol(); err != nil {
+		t.Errorf("Error creating node: %v", err)
+	}
 
 	return n1, n2
 }
@@ -66,16 +72,8 @@ type keyPair struct {
 
 func TestReconnect(t *testing.T) {
 	glog.Infof("\n\nTesting Reconnect...")
-	priv1, pub1, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
-	no1, _ := NewNode(15000, priv1, pub1, NewBasicNotifiee(nil))
-	n1, _ := NewBasicVideoNetwork(no1)
-
-	priv2, pub2, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
-	no2, _ := NewNode(15001, priv2, pub2, &BasicNotifiee{})
-	n2, _ := NewBasicVideoNetwork(no2)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
-	go n1.SetupProtocol()
-	go n2.SetupProtocol()
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 
@@ -91,7 +89,8 @@ func TestReconnect(t *testing.T) {
 	if err := n2.NetworkNode.PeerHost.Close(); err != nil {
 		t.Errorf("Error closing host: %v", err)
 	}
-	no2, _ = NewNode(15001, priv2, pub2, &BasicNotifiee{})
+	priv2, pub2, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	no2, _ := NewNode(15001, priv2, pub2, &BasicNotifiee{})
 	n2, _ = NewBasicVideoNetwork(no2)
 	go n2.SetupProtocol()
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
@@ -110,7 +109,7 @@ func TestReconnect(t *testing.T) {
 
 func TestStream(t *testing.T) {
 	glog.Infof("\n\nTesting Stream...")
-	n1, n2 := setupNodes(15000, 15001)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 	go n1.SetupProtocol()
@@ -323,7 +322,7 @@ func TestSubPeerForwardPath(t *testing.T) {
 
 func TestSendBroadcast(t *testing.T) {
 	glog.Infof("\n\nTesting Broadcast Stream...")
-	n1, n3 := setupNodes(15000, 15001)
+	n1, n3 := setupNodes(t, 15000, 15001)
 	//n2 is simple node so we can register our own handler and inspect the incoming messages
 	n2, n4 := simpleNodes(15002, 15003)
 	defer n1.NetworkNode.PeerHost.Close()
@@ -402,7 +401,7 @@ func TestSendBroadcast(t *testing.T) {
 
 func TestHandleBroadcast(t *testing.T) {
 	glog.Infof("\n\nTesting Handle Broadcast...")
-	n1, _ := setupNodes(15000, 15001)
+	n1, _ := setupNodes(t, 15000, 15001)
 	n2, _ := simpleNodes(15002, 15003)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.PeerHost.Close()
@@ -500,9 +499,8 @@ func TestHandleBroadcast(t *testing.T) {
 
 func TestSendSubscribe(t *testing.T) {
 	glog.Infof("\n\nTesting Subscriber...")
-	n1, _ := setupNodes(15000, 15001)
+	n1, _ := setupNodes(t, 15000, 15001)
 	n2, _ := simpleNodes(15002, 15003)
-	go n1.SetupProtocol()
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.PeerHost.Close()
 	connectHosts(n1.NetworkNode.PeerHost, n2.PeerHost)
@@ -611,7 +609,7 @@ func TestSendSubscribe(t *testing.T) {
 }
 
 func TestHandleCancel(t *testing.T) {
-	n1, n2 := setupNodes(15000, 15001)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 
@@ -656,7 +654,7 @@ func TestHandleCancel(t *testing.T) {
 
 func TestHandleSubscribe(t *testing.T) {
 	glog.Infof("\n\nTesting Handle Subscribe...")
-	n1, n3 := setupNodes(15000, 15001)
+	n1, n3 := setupNodes(t, 15000, 15001)
 	n2, n4 := simpleNodes(15002, 15003)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n3.NetworkNode.PeerHost.Close()
@@ -664,7 +662,6 @@ func TestHandleSubscribe(t *testing.T) {
 	defer n4.PeerHost.Close()
 	connectHosts(n1.NetworkNode.PeerHost, n2.PeerHost)
 	connectHosts(n1.NetworkNode.PeerHost, n4.PeerHost)
-	go n1.SetupProtocol()
 
 	n2chan := make(chan string)
 	n2.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
@@ -765,7 +762,7 @@ func simpleRelayHandler(ws *BasicStream, t *testing.T) Msg {
 	return msg
 }
 func TestRelaying(t *testing.T) {
-	n1, n2 := setupNodes(15000, 15001)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	n3, n4 := simpleNodes(15002, 15003)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
@@ -777,8 +774,6 @@ func TestRelaying(t *testing.T) {
 
 	strmID := peer.IDHexEncode(n1.NetworkNode.Identity) + "strmID"
 	b1, _ := n1.GetBroadcaster(strmID)
-	go n1.SetupProtocol()
-	go n2.SetupProtocol()
 
 	//Send Sub message from n3 to n1 (should relay through n2)
 	s3 := n3.GetStream(n2.NetworkNode.Identity)
@@ -874,7 +869,7 @@ func TestRelaying(t *testing.T) {
 func TestSendTranscodeResponse(t *testing.T) {
 	glog.Infof("\n\nTesting Handle Transcode Result...")
 	//n1 -> n2 -> n3, n3 should get the result, n2 should relay it, n1 should send it.
-	n1, n2 := setupNodes(15000, 15001)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	n3, n4 := simpleNodes(15003, 15004)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
@@ -882,8 +877,6 @@ func TestSendTranscodeResponse(t *testing.T) {
 	defer n4.PeerHost.Close()
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
 	connectHosts(n2.NetworkNode.PeerHost, n3.PeerHost)
-	go n1.SetupProtocol()
-	go n2.SetupProtocol()
 
 	//Set up n3 to capture the message
 	rc := make(chan map[string]string)
@@ -926,15 +919,13 @@ func TestSendTranscodeResponse(t *testing.T) {
 }
 
 func TestHandleGetMasterPlaylist(t *testing.T) {
-	n1, n2 := setupNodes(15000, 15001)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	n3, n4 := simpleNodes(15003, 15004)
 	connectHosts(n1.NetworkNode.PeerHost, n3.PeerHost)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 	defer n3.PeerHost.Close()
 	defer n4.PeerHost.Close()
-	go n1.SetupProtocol()
-	go n2.SetupProtocol()
 	n3Chan := make(chan MasterPlaylistDataMsg)
 	n3.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
 		defer s.Reset()
@@ -1023,15 +1014,13 @@ func TestHandleGetMasterPlaylist(t *testing.T) {
 }
 
 func TestHandleMasterPlaylistData(t *testing.T) {
-	n1, n2 := setupNodes(15000, 15001)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	n3, n4 := simpleNodes(15003, 15004)
 	connectHosts(n1.NetworkNode.PeerHost, n3.PeerHost)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 	defer n3.PeerHost.Close()
 	defer n4.PeerHost.Close()
-	go n1.SetupProtocol()
-	go n2.SetupProtocol()
 
 	//Set up no relayer and no receiving playlist channel. Should get error
 	strmID := fmt.Sprintf("%vstrmID", peer.IDHexEncode(n1.NetworkNode.Identity))
@@ -1111,18 +1100,19 @@ func TestHandleMasterPlaylistData(t *testing.T) {
 
 func TestMasterPlaylistIntegration(t *testing.T) {
 	glog.Infof("\n\nTesting handle master playlist")
-	n1, n3 := setupNodes(15000, 15001)
+	n1, n3 := setupNodes(t, 15000, 15001)
 
 	priv, pub, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
 	no2, _ := NewNode(15003, priv, pub, &BasicNotifiee{})
 	n2, _ := NewBasicVideoNetwork(no2)
+	if err := n2.SetupProtocol(); err != nil {
+		t.Errorf("Error: %v", err)
+	}
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 	defer n3.NetworkNode.PeerHost.Close()
 
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
-	go n1.SetupProtocol()
-	go n2.SetupProtocol()
 
 	//Create Playlist
 	mpl := m3u8.NewMasterPlaylist()

--- a/basic_stream.go
+++ b/basic_stream.go
@@ -77,6 +77,7 @@ func (bs *BasicStream) encodeAndFlush(n interface{}) error {
 	}
 
 	bs.el.Lock()
+	defer bs.el.Unlock()
 	err := bs.enc.Encode(n)
 	if err != nil {
 		glog.Errorf("send message encode error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
@@ -88,7 +89,6 @@ func (bs *BasicStream) encodeAndFlush(n interface{}) error {
 		glog.Errorf("send message flush error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
 		return ErrStream
 	}
-	bs.el.Unlock()
 
 	return nil
 }

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,5 @@ dependencies:
 
 test:
   override:
-    - cd "$HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet" && git fetch && git checkout $CIRCLE_BRANCH && git pull && gx-go get github.com/livepeer/go-livepeer-basicnet && go test
+    - cd "$HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet" && git fetch && git checkout $CIRCLE_BRANCH && git pull && gx-go get github.com/livepeer/go-livepeer-basicnet 
+    - cd "$HOME/.go_workspace/src/github.com/livepeer/go-livepeer-basicnet" && go test

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,13 +11,11 @@ import (
 )
 
 func TestRestream(t *testing.T) {
-	n1, n2 := setupNodes(15000, 15001)
+	n1, n2 := setupNodes(t, 15000, 15001)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
-	go n1.SetupProtocol()
-	go n2.SetupProtocol()
 
 	//Set up 1 broadcaster on n1
 	strmID1 := fmt.Sprintf("%vOriginalStrm", n1.GetNodeID())


### PR DESCRIPTION
2 changes in this PR:
* Removed a deadlock case in BasicStream (if the stream errors out, we never released the lock)
* Changed how error handling works in the network protocol.  Becoming a little more lenient about dropping connections - a lot of times unexpected messages get delivered to us, we shouldn't just drop the connection right away.