### PR TITLE
In/Out Streams

### DIFF
--- a/basic_broadcaster.go
+++ b/basic_broadcaster.go
@@ -14,7 +14,7 @@ type BasicBroadcaster struct {
 	Network      *BasicVideoNetwork
 	lastMsgs     []*StreamDataMsg
 	q            chan *StreamDataMsg
-	listeners    map[string]*BasicStream
+	listeners    map[string]*BasicOutStream
 	StrmID       string
 	working      bool
 	cancelWorker context.CancelFunc
@@ -62,7 +62,7 @@ func (b *BasicBroadcaster) Finish() error {
 func (br *BasicBroadcaster) AddListener(nw *BasicVideoNetwork, pid peer.ID) {
 	key := peer.IDHexEncode(pid)
 	if _, ok := br.listeners[key]; !ok {
-		br.listeners[key] = nw.NetworkNode.GetStream(pid)
+		br.listeners[key] = nw.NetworkNode.GetOutStream(pid)
 	}
 }
 
@@ -81,7 +81,7 @@ func (b *BasicBroadcaster) broadcastToListeners(ctx context.Context) {
 	}
 }
 
-func (b *BasicBroadcaster) sendDataMsg(lid string, l *BasicStream, msg *StreamDataMsg) {
+func (b *BasicBroadcaster) sendDataMsg(lid string, l *BasicOutStream, msg *StreamDataMsg) {
 	if msg == nil {
 		return
 	}

--- a/basic_in_stream.go
+++ b/basic_in_stream.go
@@ -24,7 +24,7 @@ func NewBasicInStream(s net.Stream) *BasicInStream {
 	// This is where we pick our specific multicodec. In order to change the
 	// codec, we only need to change this place.
 	// See https://godoc.org/github.com/multiformats/go-multicodec/json
-	dec := mcjson.Multicodec(false).Decoder(reader)
+	dec := mcjson.Multicodec(true).Decoder(reader)
 
 	return &BasicInStream{
 		Stream: s,

--- a/basic_in_stream.go
+++ b/basic_in_stream.go
@@ -1,0 +1,45 @@
+package basicnet
+
+import (
+	"bufio"
+
+	net "gx/ipfs/QmNa31VPzC561NWwRsJLE7nGYZYuuD2QfpK2b1q9BK54J1/go-libp2p-net"
+
+	multicodec "github.com/multiformats/go-multicodec"
+	mcjson "github.com/multiformats/go-multicodec/json"
+
+	"github.com/golang/glog"
+)
+
+//BasicStream is a libp2p stream wrapped in a reader and a writer.
+type BasicInStream struct {
+	Stream net.Stream
+	dec    multicodec.Decoder
+	r      *bufio.Reader
+}
+
+//NewBasicStream creates a stream from a libp2p raw stream.
+func NewBasicInStream(s net.Stream) *BasicInStream {
+	reader := bufio.NewReader(s)
+	// This is where we pick our specific multicodec. In order to change the
+	// codec, we only need to change this place.
+	// See https://godoc.org/github.com/multiformats/go-multicodec/json
+	dec := mcjson.Multicodec(false).Decoder(reader)
+
+	return &BasicInStream{
+		Stream: s,
+		r:      reader,
+		dec:    dec,
+	}
+}
+
+//ReceiveMessage takes a message off the stream.
+func (bs *BasicInStream) ReceiveMessage() (Msg, error) {
+	msg := Msg{}
+	err := bs.dec.Decode(&msg)
+	if err != nil && err.Error() == "multicodec did not match" {
+		glog.Infof("\n\nmulticode did not match")
+	}
+
+	return msg, err
+}

--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -901,8 +901,6 @@ func TestSendTranscodeResponse(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error sending transcode result: %v", err)
 			}
-			glog.Infof("sent i: %v", i)
-			time.Sleep(10 * time.Millisecond) //I hate this sleep, but things don't work without it.  Fille https://github.com/libp2p/go-libp2p/issues/250.
 		}
 	}()
 

--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -62,7 +62,7 @@ func connectHosts(h1, h2 host.Host) {
 	}
 
 	// Connection might not be formed right away under high load.  See https://github.com/libp2p/go-libp2p-kad-dht/blob/master/dht_test.go (func connect)
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(time.Millisecond * 100)
 }
 
 type keyPair struct {
@@ -78,7 +78,7 @@ func TestReconnect(t *testing.T) {
 	defer n2.NetworkNode.PeerHost.Close()
 
 	//Send a message, it should work
-	s := n2.NetworkNode.GetStream(n1.NetworkNode.Identity)
+	s := n2.NetworkNode.GetOutStream(n1.NetworkNode.Identity)
 	if err := s.SendMessage(GetMasterPlaylistReqID, GetMasterPlaylistReqMsg{StrmID: "strmID1"}); err != nil {
 		t.Errorf("Error sending message: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestReconnect(t *testing.T) {
 	n2, _ = NewBasicVideoNetwork(no2)
 	go n2.SetupProtocol()
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
-	s = n2.NetworkNode.GetStream(n1.NetworkNode.Identity)
+	s = n2.NetworkNode.GetOutStream(n1.NetworkNode.Identity)
 	if s == nil || s.Stream == nil {
 		t.Errorf("Got nil for stream to: %v", n1.NetworkNode.Identity)
 	}
@@ -119,14 +119,14 @@ func TestStream(t *testing.T) {
 	strmID1 := fmt.Sprintf("%vstrmID", peer.IDHexEncode(n1.NetworkNode.Identity))
 	strmID2 := fmt.Sprintf("%vstrmID", peer.IDHexEncode(n2.NetworkNode.Identity))
 	//Should be able to send messages back and forth
-	s12 := n1.NetworkNode.GetStream(n2.NetworkNode.Identity)
+	s12 := n1.NetworkNode.GetOutStream(n2.NetworkNode.Identity)
 	if err := s12.SendMessage(SubReqID, SubReqMsg{StrmID: strmID2}); err != nil {
 		t.Errorf("Error: %v", err)
 	}
 	if _, ok := n1.NetworkNode.outStreams[n2.NetworkNode.Identity]; !ok {
 		t.Errorf("Expecting stream to be there")
 	}
-	s21 := n2.NetworkNode.GetStream(n1.NetworkNode.Identity)
+	s21 := n2.NetworkNode.GetOutStream(n1.NetworkNode.Identity)
 	if err := s21.SendMessage(SubReqID, SubReqMsg{StrmID: strmID1}); err != nil {
 		t.Errorf("Error: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestSubPath(t *testing.T) {
 
 	strmID := fmt.Sprintf("%v%v", nodes[0].GetNodeID(), "strmID")
 	hostsLookup[ids[0]].SetStreamHandler(Protocol, func(s net.Stream) {
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		msg, err := ws.ReceiveMessage()
 		if err != nil {
 			t.Errorf("Error receiving msg: %v", err)
@@ -213,7 +213,7 @@ func TestSubPath(t *testing.T) {
 			t.Errorf("Expecting Sub")
 		}
 		time.Sleep(100 * time.Millisecond)
-		if err := nodes[0].NetworkNode.GetStream(s.Conn().RemotePeer()).SendMessage(StreamDataID, StreamDataMsg{StrmID: strmID, Data: []byte("Hello from n0")}); err != nil {
+		if err := nodes[0].NetworkNode.GetOutStream(s.Conn().RemotePeer()).SendMessage(StreamDataID, StreamDataMsg{StrmID: strmID, Data: []byte("Hello from n0")}); err != nil {
 			t.Errorf("Error sending message from n0: %v", err)
 		}
 	})
@@ -244,8 +244,8 @@ func TestSubPath(t *testing.T) {
 }
 
 func newNode(pid peer.ID, dht *kad.IpfsDHT, rHost host.Host) *NetworkNode {
-	streams := make(map[peer.ID]*BasicStream)
-	nn := &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, outStreams: streams, outStreamsLock: &sync.RWMutex{}}
+	streams := make(map[peer.ID]*BasicOutStream)
+	nn := &NetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, outStreams: streams, outStreamsLock: &sync.Mutex{}}
 	return nn
 }
 
@@ -279,7 +279,7 @@ func TestSubPeerForwardPath(t *testing.T) {
 
 	n3chan := make(chan bool)
 	no3.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		_, err := ws.ReceiveMessage()
 		if err != nil {
 			t.Errorf("Error receiving msg: %v", err)
@@ -290,7 +290,7 @@ func TestSubPeerForwardPath(t *testing.T) {
 
 	n2chan := make(chan bool)
 	no2.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		_, err := ws.ReceiveMessage()
 		if err != nil {
 			t.Errorf("Error receiving msg: %v", err)
@@ -335,7 +335,7 @@ func TestSendBroadcast(t *testing.T) {
 	var finishStrm FinishStreamMsg
 	//Set up handler
 	n2.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		msg, err := ws.ReceiveMessage()
 		if err != nil {
 			glog.Errorf("Got error decoding msg: %v", err)
@@ -359,7 +359,7 @@ func TestSendBroadcast(t *testing.T) {
 	}
 
 	//Add the stream as a listner in the broadcaster so it can be used to send out the message
-	b1.listeners[peer.IDHexEncode(ns1.Conn().RemotePeer())] = NewBasicStream(ns1)
+	b1.listeners[peer.IDHexEncode(ns1.Conn().RemotePeer())] = NewBasicOutStream(ns1)
 
 	if b1.working != false {
 		t.Errorf("broadcaster shouldn't be working yet")
@@ -410,7 +410,7 @@ func TestHandleBroadcast(t *testing.T) {
 	cancelChan := make(chan CancelSubMsg)
 	//Set up n2 handler so n1 can create a stream to it.
 	n2.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		msg, err := ws.ReceiveMessage()
 		if err != nil {
 			glog.Errorf("Got error decoding msg: %v", err)
@@ -435,11 +435,11 @@ func TestHandleBroadcast(t *testing.T) {
 	ctxW, cancel := context.WithCancel(context.Background())
 	s1.cancelWorker = cancel
 	s1.working = true
-	s1.networkStream = n1.NetworkNode.GetStream(n2.Identity)
+	outStrm := n1.NetworkNode.GetOutStream(n2.Identity)
 	var seqNoResult uint64
 	var dataResult []byte
 	s1GotMsgChan := make(chan struct{})
-	s1.startWorker(ctxW, n2.Identity, s1.networkStream, func(seqNo uint64, data []byte, eof bool) {
+	s1.startWorker(ctxW, n2.Identity, outStrm, func(seqNo uint64, data []byte, eof bool) {
 		seqNoResult = seqNo
 		dataResult = data
 		s1GotMsgChan <- struct{}{}
@@ -489,9 +489,9 @@ func TestHandleBroadcast(t *testing.T) {
 	if s1.working {
 		t.Errorf("Subscriber worker shouldn't be working anymore")
 	}
-	if s1.networkStream != nil {
-		t.Errorf("networkStream should be nil, but got: %v", s1.networkStream)
-	}
+	// if s1.networkStream != nil {
+	// 	t.Errorf("networkStream should be nil, but got: %v", s1.networkStream)
+	// }
 	if cancelMsg.StrmID != "strmID" {
 		t.Errorf("Expecting cancelMsg.StrmID to be 'strmID' (cancelMsg to be sent because of cancelWorker()), but got %v", cancelMsg.StrmID)
 	}
@@ -509,7 +509,7 @@ func TestSendSubscribe(t *testing.T) {
 	var cancelMsg CancelSubMsg
 	//Set up handler for simple node (get a subReqMsg, write a streamDataMsg back)
 	n2.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		for {
 			msg, err := ws.ReceiveMessage()
 			if err != nil {
@@ -525,7 +525,7 @@ func TestSendSubscribe(t *testing.T) {
 					//TODO: Sleep here is needed, because we can't handle the messages fast enough.
 					//I think we need to re-organize our code to kick off goroutines / workers instead of handling everything in a for loop.
 					time.Sleep(time.Millisecond * 100)
-					if err := n2.GetStream(ws.Stream.Conn().RemotePeer()).SendMessage(StreamDataID, StreamDataMsg{SeqNo: uint64(i), StrmID: subReq.StrmID, Data: []byte("test data")}); err != nil {
+					if err := n2.GetOutStream(ws.Stream.Conn().RemotePeer()).SendMessage(StreamDataID, StreamDataMsg{SeqNo: uint64(i), StrmID: subReq.StrmID, Data: []byte("test data")}); err != nil {
 						t.Errorf("Error sending data back to n1: %v", err)
 					}
 				}
@@ -617,7 +617,7 @@ func TestHandleCancel(t *testing.T) {
 	nid2, _ := peer.IDHexDecode("1220fd6156923c7138dc1b4388ab59a3eb0631c4e673499d35d47f1af32f2c92de66")
 	//Put a broadcaster with a single listener in the node, make sure cancel removes the listener
 	strmID1 := "strmID1"
-	b := &BasicBroadcaster{listeners: map[string]*BasicStream{peer.IDHexEncode(nid1): nil}}
+	b := &BasicBroadcaster{listeners: map[string]*BasicOutStream{peer.IDHexEncode(nid1): nil}}
 	n1.broadcasters[strmID1] = b
 	if err := handleCancelSubReq(n1, CancelSubMsg{StrmID: strmID1}, nid1); err != nil {
 		t.Errorf("Error handling req: %v", err)
@@ -628,7 +628,7 @@ func TestHandleCancel(t *testing.T) {
 	delete(n1.broadcasters, strmID1)
 
 	//Put a relayer with 2 listeners in the node, make sure cancel removes the listener, then the relayer
-	r := &BasicRelayer{listeners: map[string]*BasicStream{peer.IDHexEncode(nid1): nil, peer.IDHexEncode(nid2): nil}}
+	r := &BasicRelayer{listeners: map[string]*BasicOutStream{peer.IDHexEncode(nid1): nil, peer.IDHexEncode(nid2): nil}}
 	n1.relayers[relayerMapKey(strmID1, SubReqID)] = r
 	if err := handleCancelSubReq(n1, CancelSubMsg{StrmID: strmID1}, nid1); err != nil {
 		t.Errorf("Error handling req: %v", err)
@@ -666,7 +666,7 @@ func TestHandleSubscribe(t *testing.T) {
 	n2chan := make(chan string)
 	n2.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
 		defer s.Close()
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		for {
 			msg, err := ws.ReceiveMessage()
 			if err != nil {
@@ -681,7 +681,7 @@ func TestHandleSubscribe(t *testing.T) {
 	n4chan := make(chan string)
 	n4.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
 		defer s.Close()
-		ws := NewBasicStream(s)
+		ws := NewBasicInStream(s)
 		for {
 			msg, err := ws.ReceiveMessage()
 			if err != nil {
@@ -700,14 +700,14 @@ func TestHandleSubscribe(t *testing.T) {
 	b1, _ := b1tmp.(*BasicBroadcaster)
 	b1.lastMsgs = []*StreamDataMsg{&StreamDataMsg{SeqNo: 0, StrmID: strmID, Data: []byte("hello")}}
 	n1.broadcasters[strmID] = b1
-	ws := n1.NetworkNode.GetStream(n2.Identity)
+	ws := n1.NetworkNode.GetOutStream(n2.Identity)
 	if err := handleSubReq(n1, SubReqMsg{StrmID: strmID}, n2.Identity); err != nil {
 		t.Errorf("Error handling sub req: %v", err)
 	}
 
 	l := b1.listeners[peer.IDHexEncode(n2.Identity)]
-	if l == nil || reflect.TypeOf(l) != reflect.TypeOf(&BasicStream{}) {
-		t.Errorf("Expecting l to be assigned a BasicStream, but got :%v", reflect.TypeOf(l))
+	if l == nil || reflect.TypeOf(l) != reflect.TypeOf(&BasicOutStream{}) {
+		t.Errorf("Expecting l to be assigned a BasicOutStream, but got :%v", reflect.TypeOf(l))
 	}
 
 	timer := time.NewTimer(time.Second)
@@ -730,7 +730,7 @@ func TestHandleSubscribe(t *testing.T) {
 	if n1.relayers[relayerMapKey(strmID2, SubReqID)] != r1 {
 		t.Errorf("Should have assigned relayer")
 	}
-	ws = n1.NetworkNode.GetStream(n2.Identity)
+	ws = n1.NetworkNode.GetOutStream(n2.Identity)
 	if err := handleSubReq(n1, SubReqMsg{StrmID: strmID2}, n2.Identity); err != nil {
 		t.Errorf("Error handling sub req: %v", err)
 	}
@@ -753,7 +753,7 @@ func TestHandleSubscribe(t *testing.T) {
 
 }
 
-func simpleRelayHandler(ws *BasicStream, t *testing.T) Msg {
+func simpleRelayHandler(ws *BasicInStream, t *testing.T) Msg {
 	msg, err := ws.ReceiveMessage()
 	if err != nil {
 		// glog.Errorf("Got error decoding msg: %v", err)
@@ -776,14 +776,14 @@ func TestRelaying(t *testing.T) {
 	b1, _ := n1.GetBroadcaster(strmID)
 
 	//Send Sub message from n3 to n1 (should relay through n2)
-	s3 := n3.GetStream(n2.NetworkNode.Identity)
+	s3 := n3.GetOutStream(n2.NetworkNode.Identity)
 	s3.SendMessage(SubReqID, SubReqMsg{StrmID: strmID})
 
 	var strmDataResult StreamDataMsg
 	var finishResult FinishStreamMsg
 	var ok bool
 	n3.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
-		strm := NewBasicStream(s)
+		strm := NewBasicInStream(s)
 		for {
 			// glog.Infof("Got msg: %v", msg)
 			msg := simpleRelayHandler(strm, t)
@@ -870,11 +870,10 @@ func TestSendTranscodeResponse(t *testing.T) {
 	glog.Infof("\n\nTesting Handle Transcode Result...")
 	//n1 -> n2 -> n3, n3 should get the result, n2 should relay it, n1 should send it.
 	n1, n2 := setupNodes(t, 15000, 15001)
-	n3, n4 := simpleNodes(15003, 15004)
+	n3, _ := simpleNodes(15003, 15004)
 	defer n1.NetworkNode.PeerHost.Close()
 	defer n2.NetworkNode.PeerHost.Close()
 	defer n3.PeerHost.Close()
-	defer n4.PeerHost.Close()
 	connectHosts(n1.NetworkNode.PeerHost, n2.NetworkNode.PeerHost)
 	connectHosts(n2.NetworkNode.PeerHost, n3.PeerHost)
 
@@ -882,31 +881,43 @@ func TestSendTranscodeResponse(t *testing.T) {
 	rc := make(chan map[string]string)
 	n3.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
 		defer s.Close()
-		ws := NewBasicStream(s)
-		msg, err := ws.ReceiveMessage()
-		if err != nil {
-			t.Errorf("Error: %v", err)
+		ws := NewBasicInStream(s)
+		for {
+			msg, err := ws.ReceiveMessage()
+			if err != nil {
+				glog.Infof("Error: %v", err)
+				break
+			}
+			glog.Infof("n3 got Msg: %v", msg)
+			rc <- msg.Data.(TranscodeResponseMsg).Result
 		}
-		glog.Infof("n3 got Msg: %v", msg)
-		rc <- msg.Data.(TranscodeResponseMsg).Result
 	})
 
 	strmID := fmt.Sprintf("%vstrmID", peer.IDHexEncode(n3.Identity))
 	//Send the message
-	err := n1.SendTranscodeResponse(peer.IDHexEncode(n3.Identity), strmID, map[string]string{"strmid1": lpms.P240p30fps4x3.Name, "strmid2": lpms.P360p30fps4x3.Name})
-	if err != nil {
-		t.Errorf("Error sending transcode result: %v", err)
-	}
-	select {
-	case r := <-rc:
-		if r["strmid1"] != lpms.P240p30fps4x3.Name {
-			t.Errorf("Expecting %v, got %v", lpms.P240p30fps4x3.Name, r["strmid1"])
+	go func() {
+		for i := 0; i < 3; i++ {
+			err := n1.SendTranscodeResponse(peer.IDHexEncode(n3.Identity), fmt.Sprintf("%v:%v", strmID, i), map[string]string{"strmid1": lpms.P240p30fps4x3.Name, "strmid2": lpms.P360p30fps4x3.Name})
+			if err != nil {
+				t.Errorf("Error sending transcode result: %v", err)
+			}
+			glog.Infof("sent i: %v", i)
+			time.Sleep(10 * time.Millisecond) //I hate this sleep, but things don't work without it.  Fille https://github.com/libp2p/go-libp2p/issues/250.
 		}
-		if r["strmid2"] != lpms.P360p30fps4x3.Name {
-			t.Errorf("Expecting %v, got %v", lpms.P360p30fps4x3.Name, r["strmid2"])
+	}()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case r := <-rc:
+			if r["strmid1"] != lpms.P240p30fps4x3.Name {
+				t.Errorf("Expecting %v, got %v", lpms.P240p30fps4x3.Name, r["strmid1"])
+			}
+			if r["strmid2"] != lpms.P360p30fps4x3.Name {
+				t.Errorf("Expecting %v, got %v", lpms.P360p30fps4x3.Name, r["strmid2"])
+			}
+		case <-time.After(time.Second * 5):
+			t.Errorf("Timed out")
 		}
-	case <-time.After(time.Second * 5):
-		t.Errorf("Timed out")
 	}
 
 	// r, ok := n2.relayers[relayerMapKey(strmID, TranscodeResponseID)]
@@ -929,7 +940,7 @@ func TestHandleGetMasterPlaylist(t *testing.T) {
 	n3Chan := make(chan MasterPlaylistDataMsg)
 	n3.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
 		defer s.Reset()
-		strm := NewBasicStream(s)
+		strm := NewBasicInStream(s)
 		for {
 			msg, err := strm.ReceiveMessage()
 			if err != nil {
@@ -1036,12 +1047,12 @@ func TestHandleMasterPlaylistData(t *testing.T) {
 	//Set up a relayer, make sure it's relaying to the right destination
 	n3Chan := make(chan MasterPlaylistDataMsg)
 	n3.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
-		strm := NewBasicStream(s)
+		strm := NewBasicInStream(s)
 		msg, _ := strm.ReceiveMessage()
 		n3Chan <- msg.Data.(MasterPlaylistDataMsg)
 	})
-	strm := n1.NetworkNode.GetStream(n3.Identity)
-	r := &BasicRelayer{listeners: map[string]*BasicStream{peer.IDHexEncode(n3.Identity): strm}}
+	strm := n1.NetworkNode.GetOutStream(n3.Identity)
+	r := &BasicRelayer{listeners: map[string]*BasicOutStream{peer.IDHexEncode(n3.Identity): strm}}
 	n1.relayers[relayerMapKey(strmID, GetMasterPlaylistReqID)] = r
 	if err := handleMasterPlaylistDataMsg(n1, MasterPlaylistDataMsg{StrmID: strmID, NotFound: true}); err != nil {
 		t.Errorf("Error: %v", err)

--- a/basic_out_stream.go
+++ b/basic_out_stream.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"sync"
 
 	net "gx/ipfs/QmNa31VPzC561NWwRsJLE7nGYZYuuD2QfpK2b1q9BK54J1/go-libp2p-net"
@@ -16,62 +15,41 @@ import (
 	"github.com/golang/glog"
 )
 
-var ErrStream = errors.New("ErrStream")
+var ErrOutStream = errors.New("ErrOutStream")
 
 //BasicStream is a libp2p stream wrapped in a reader and a writer.
-type BasicStream struct {
+type BasicOutStream struct {
 	Stream net.Stream
 	enc    multicodec.Encoder
-	dec    multicodec.Decoder
 	w      *bufio.Writer
-	r      *bufio.Reader
 	el     *sync.Mutex
-	dl     *sync.Mutex
 }
 
 //NewBasicStream creates a stream from a libp2p raw stream.
-func NewBasicStream(s net.Stream) *BasicStream {
-	reader := bufio.NewReader(s)
+func NewBasicOutStream(s net.Stream) *BasicOutStream {
 	writer := bufio.NewWriter(s)
 	// This is where we pick our specific multicodec. In order to change the
 	// codec, we only need to change this place.
 	// See https://godoc.org/github.com/multiformats/go-multicodec/json
-	dec := mcjson.Multicodec(false).Decoder(reader)
 	enc := mcjson.Multicodec(false).Encoder(writer)
 
-	return &BasicStream{
+	return &BasicOutStream{
 		Stream: s,
-		r:      reader,
 		w:      writer,
 		enc:    enc,
-		dec:    dec,
 		el:     &sync.Mutex{},
-		dl:     &sync.Mutex{},
 	}
-}
-
-//ReceiveMessage takes a message off the stream.
-func (bs *BasicStream) ReceiveMessage() (Msg, error) {
-	bs.dl.Lock()
-	defer bs.dl.Unlock()
-	var msg Msg
-	err := bs.dec.Decode(&msg)
-	if err != nil && err.Error() == "multicodec did not match" {
-		msg, err := ioutil.ReadAll(bs.r)
-		glog.Infof("\n\nmulticode did not match...\nmsg:%v\nmsgstr:%s\nerr:%v\n\n", msg, string(msg), err)
-	}
-	return msg, err
 }
 
 //SendMessage writes a message into the stream.
-func (bs *BasicStream) SendMessage(opCode Opcode, data interface{}) error {
+func (bs *BasicOutStream) SendMessage(opCode Opcode, data interface{}) error {
 	// glog.V(common.DEBUG).Infof("Sending msg %v to %v", opCode, peer.IDHexEncode(bs.Stream.Conn().RemotePeer()))
 	msg := Msg{Op: opCode, Data: data}
 	return bs.encodeAndFlush(msg)
 }
 
 //EncodeAndFlush writes a message into the stream.
-func (bs *BasicStream) encodeAndFlush(n interface{}) error {
+func (bs *BasicOutStream) encodeAndFlush(n interface{}) error {
 	if bs == nil {
 		fmt.Println("stream is nil")
 	}
@@ -81,13 +59,13 @@ func (bs *BasicStream) encodeAndFlush(n interface{}) error {
 	err := bs.enc.Encode(n)
 	if err != nil {
 		glog.Errorf("send message encode error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
-		return ErrStream
+		return ErrOutStream
 	}
 
 	err = bs.w.Flush()
 	if err != nil {
 		glog.Errorf("send message flush error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
-		return ErrStream
+		return ErrOutStream
 	}
 
 	return nil

--- a/basic_out_stream.go
+++ b/basic_out_stream.go
@@ -31,7 +31,7 @@ func NewBasicOutStream(s net.Stream) *BasicOutStream {
 	// This is where we pick our specific multicodec. In order to change the
 	// codec, we only need to change this place.
 	// See https://godoc.org/github.com/multiformats/go-multicodec/json
-	enc := mcjson.Multicodec(false).Encoder(writer)
+	enc := mcjson.Multicodec(true).Encoder(writer)
 
 	return &BasicOutStream{
 		Stream: s,

--- a/basic_relayer.go
+++ b/basic_relayer.go
@@ -13,7 +13,7 @@ import (
 //does NOT have a worker - it sends out the chunks to its listeners as soon as it gets one from the network.
 type BasicRelayer struct {
 	UpstreamPeer peer.ID
-	listeners    map[string]*BasicStream
+	listeners    map[string]*BasicOutStream
 	LastRelay    time.Time
 }
 
@@ -56,7 +56,7 @@ func (br *BasicRelayer) RelayMasterPlaylistData(nw *BasicVideoNetwork, mpld Mast
 func (br *BasicRelayer) AddListener(nw *BasicVideoNetwork, pid peer.ID) {
 	key := peer.IDHexEncode(pid)
 	if _, ok := br.listeners[key]; !ok {
-		br.listeners[key] = nw.NetworkNode.GetStream(pid)
+		br.listeners[key] = nw.NetworkNode.GetOutStream(pid)
 	}
 }
 

--- a/libp2p_playground_test.go
+++ b/libp2p_playground_test.go
@@ -126,8 +126,8 @@ func simpleNodes(p1, p2 int) (*NetworkNode, *NetworkNode) {
 	return n1, n2
 }
 
-func simpleHandler(ns net.Stream, txt string) error {
-	ws := NewBasicStream(ns)
+func simpleHandler(host host.Host, ns net.Stream, txt string) error {
+	ws := NewBasicInStream(ns)
 
 	msg, err := ws.ReceiveMessage()
 
@@ -139,13 +139,25 @@ func simpleHandler(ns net.Stream, txt string) error {
 	// time.Sleep(100 * time.Millisecond)
 
 	glog.Infof("Sending %v", txt)
-	ws.SendMessage(0, StreamDataMsg{Data: []byte(txt)})
+	os, err := host.NewStream(context.Background(), ns.Conn().RemotePeer())
+	if err != nil {
+		glog.Errorf("Error creating out stream: %v", err)
+		return err
+	}
+	outStrm := NewBasicOutStream(os)
+	outStrm.SendMessage(0, StreamDataMsg{Data: []byte(txt)})
 	return nil
 }
 
-func simpleHandlerLoop(ws *BasicStream, txt string) {
+func simpleHandlerLoop(host host.Host, ws *BasicInStream, txt string) {
+	msg, err := ws.ReceiveMessage()
+	os, err := host.NewStream(context.Background(), ws.Stream.Conn().RemotePeer())
+	if err != nil {
+		glog.Errorf("Error creating out stream: %v", err)
+	}
+	outStrm := NewBasicOutStream(os)
+
 	for {
-		msg, err := ws.ReceiveMessage()
 
 		if err != nil {
 			glog.Errorf("Got error decoding msg: %v", err)
@@ -153,12 +165,12 @@ func simpleHandlerLoop(ws *BasicStream, txt string) {
 		}
 		glog.Infof("%v Got msg: %v", ws.Stream.Conn().LocalPeer().Pretty(), msg)
 
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 
 		newMsg := Msg{Data: string(msg.Data.([]byte)) + "|" + txt, Op: StreamDataID}
 
 		glog.Infof("Sending %v", newMsg)
-		err = ws.SendMessage(0, newMsg)
+		err = outStrm.SendMessage(0, newMsg)
 		if err != nil {
 			glog.Errorf("Failed to send message %v: %v", newMsg, err)
 		}
@@ -166,7 +178,7 @@ func simpleHandlerLoop(ws *BasicStream, txt string) {
 }
 
 func simpleSend(ns net.Stream, txt string, t *testing.T) {
-	ws := NewBasicStream(ns)
+	ws := NewBasicOutStream(ns)
 	ws.SendMessage(0, txt)
 }
 
@@ -223,7 +235,7 @@ func TestBasic(t *testing.T) {
 	h2.SetStreamHandler(Protocol, func(stream net.Stream) {
 		glog.Infof("h2 handler...")
 		for {
-			if err := simpleHandler(stream, "pong"); err != nil {
+			if err := simpleHandler(h2, stream, "pong"); err != nil {
 				stream.Close()
 				return
 			}
@@ -234,7 +246,7 @@ func TestBasic(t *testing.T) {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	s1 := NewBasicStream(stream)
+	s1 := NewBasicOutStream(stream)
 	s1.SendMessage(0, StreamDataMsg{Data: []byte("ping1")})
 	time.Sleep(time.Millisecond * 200)
 
@@ -254,7 +266,7 @@ func TestUniDirection(t *testing.T) {
 	h2.SetStreamHandler(Protocol, func(stream net.Stream) {
 		glog.Infof("h2 handler...")
 		for {
-			ws := NewBasicStream(stream)
+			ws := NewBasicInStream(stream)
 			msg, err := ws.ReceiveMessage()
 			if err != nil {
 				glog.Errorf("Got error decoding msg: %v", err)
@@ -267,7 +279,7 @@ func TestUniDirection(t *testing.T) {
 	h1.SetStreamHandler(Protocol, func(stream net.Stream) {
 		glog.Infof("h1 handler...")
 		for {
-			ws := NewBasicStream(stream)
+			ws := NewBasicInStream(stream)
 			msg, err := ws.ReceiveMessage()
 			if err != nil {
 				glog.Errorf("Got error decoding msg: %v", err)
@@ -281,7 +293,7 @@ func TestUniDirection(t *testing.T) {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	s1 := NewBasicStream(stream)
+	s1 := NewBasicOutStream(stream)
 	if err := s1.SendMessage(0, StreamDataMsg{Data: []byte("ping1")}); err != nil {
 		glog.Infof("Error: %v", err)
 	}
@@ -296,7 +308,7 @@ func TestUniDirection(t *testing.T) {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	s2 := NewBasicStream(stream2)
+	s2 := NewBasicOutStream(stream2)
 	s2.SendMessage(0, StreamDataMsg{Data: []byte("pong1")})
 	s2.SendMessage(0, StreamDataMsg{Data: []byte("pong2")})
 	time.Sleep(time.Millisecond * 100)
@@ -330,6 +342,62 @@ func TestProvider(t *testing.T) {
 		glog.Infof("Provider for hello: %v", peer.IDHexEncode(pid.ID))
 	}
 }
+
+// func TestConcurrentSend(t *testing.T) {
+// 	n1, n2 := simpleNodes(15000, 15001)
+// 	n3, _ := simpleNodes(15002, 15003)
+// 	connectHosts(n1.PeerHost, n2.PeerHost)
+// 	connectHosts(n2.PeerHost, n3.PeerHost)
+// 	n1.PeerHost.SetStreamHandler(Protocol, func(stream net.Stream) {
+// 	})
+// 	c := make(chan string, 20)
+// 	n2.PeerHost.SetStreamHandler(Protocol, func(stream net.Stream) {
+// 		// strm := NewBasicInStream(stream)
+// 		defer stream.Reset()
+// 		for {
+// 			// if msg, err := strm.ReceiveMessage(); err != nil {
+// 			// 	glog.Infof("Error: %v", err)
+// 			// 	break
+// 			// } else {
+// 			// 	c <- string(msg.Data.(StreamDataMsg).Data)
+// 			// }
+// 			bytes := make([]byte, 500)
+// 			if _, err := stream.Read(bytes); err != nil {
+// 				glog.Infof("Error: %v", err)
+// 				break
+// 			}
+// 			c <- string(bytes)
+// 		}
+// 	})
+// 	n3.PeerHost.SetStreamHandler(Protocol, func(stream net.Stream) {
+// 	})
+
+// 	go func() {
+// 		for i := 0; i < 10; i++ {
+// 			strm := n1.GetOutStream(n2.Identity)
+// 			strm.SendMessage(StreamDataID, StreamDataMsg{Data: []byte(fmt.Sprintf("%v", i))})
+// 			time.Sleep(time.Millisecond * 2) //The 2ms is here because without it there seems to be a bug
+// 			// strm.Stream.Write([]byte(fmt.Sprintf("%v\n", i)))
+// 		}
+// 	}()
+
+// 	// go func() {
+// 	// 	for i := 100; i < 200; i++ {
+// 	// 		strm := n3.GetOutStream(n2.Identity)
+// 	// 		strm.Stream.Write([]byte(fmt.Sprintf("%v\n", i)))
+// 	// 		// strm.SendMessage(StreamDataID, StreamDataMsg{Data: []byte(fmt.Sprintf("%v", i))})
+// 	// 		// time.Sleep(time.Millisecond * 2)
+// 	// 	}
+// 	// }()
+// 	for i := 0; i < 10; i++ {
+// 		select {
+// 		case i := <-c:
+// 			fmt.Printf("got %v\n", i)
+// 		case <-time.After(5 * time.Second):
+// 			t.Errorf("Timed out")
+// 		}
+// 	}
+// }
 
 // func TestCid(t *testing.T) {
 // 	ctx := context.Background()

--- a/libp2p_playground_test.go
+++ b/libp2p_playground_test.go
@@ -289,7 +289,7 @@ func TestUniDirection(t *testing.T) {
 		}
 	})
 
-	time.Sleep(time.Millisecond * 50)
+	time.Sleep(time.Millisecond * 500)
 
 	stream, err := h1.NewStream(context.Background(), h2.ID(), Protocol)
 	if err != nil {

--- a/libp2p_playground_test.go
+++ b/libp2p_playground_test.go
@@ -289,6 +289,8 @@ func TestUniDirection(t *testing.T) {
 		}
 	})
 
+	time.Sleep(time.Millisecond * 50)
+
 	stream, err := h1.NewStream(context.Background(), h2.ID(), Protocol)
 	if err != nil {
 		glog.Fatal(err)

--- a/network_node_test.go
+++ b/network_node_test.go
@@ -1,0 +1,60 @@
+package basicnet
+
+import (
+	"fmt"
+	net "gx/ipfs/QmNa31VPzC561NWwRsJLE7nGYZYuuD2QfpK2b1q9BK54J1/go-libp2p-net"
+	crypto "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+func TestGetOutStream(t *testing.T) {
+	go func() {
+		http.ListenAndServe("localhost:6060", nil)
+	}()
+
+	priv1, pub1, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	no1, _ := NewNode(15000, priv1, pub1, &BasicNotifiee{})
+	priv2, pub2, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
+	no2, _ := NewNode(15001, priv2, pub2, &BasicNotifiee{})
+	no1.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
+	})
+	msgChan := make(chan Msg)
+	no2.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
+		is := NewBasicInStream(s)
+		for {
+			msg, err := is.ReceiveMessage()
+			if err != nil {
+				glog.Errorf("Error: %v", err)
+				break
+			}
+			msgChan <- msg
+		}
+	})
+	connectHosts(no1.PeerHost, no2.PeerHost)
+
+	for i := 0; i < 4; i++ {
+		go func(i int) {
+			strm := no1.GetOutStream(no2.Identity)
+			if strm == nil {
+				t.Errorf("Expecting an outstream")
+			}
+			time.Sleep(time.Duration(i) * 100 * time.Millisecond) //Sleep is bad, but we have a libp2p issue here.
+			if err := strm.SendMessage(StreamDataID, StreamDataMsg{Data: []byte(fmt.Sprintf("%v", i))}); err != nil {
+				t.Errorf("Error: %v", err)
+			}
+		}(i)
+	}
+
+	for i := 0; i < 4; i++ {
+		select {
+		case msg := <-msgChan:
+			glog.Infof("%v", string(msg.Data.(StreamDataMsg).Data))
+		case <-time.After(time.Second * 5):
+			t.Errorf("Timed out")
+		}
+	}
+}


### PR DESCRIPTION
In this PR:
* We removed `BasicStream`, and added `BasicInStream` and `BasicOutStream`.
* We fixed a bug were reading the multicodec error was blocking the stream (a little hard to see in this diff.  Search for "multicodec" and look at the before/after code in 2 different files)
* Enable the `msgio` package (in mcjson.Multicodec), this solves the race condition of multiple messages get concatenated together

