### PR TITLE
Bug Fix: Retry When Connection Error Happens

### DIFF
--- a/basic_broadcaster.go
+++ b/basic_broadcaster.go
@@ -47,7 +47,7 @@ func (b *BasicBroadcaster) Finish() error {
 	//Send Finish to all the listeners
 	for _, l := range b.listeners {
 		glog.V(5).Infof("Broadcasting finish")
-		if err := l.SendMessage(FinishStreamID, FinishStreamMsg{StrmID: b.StrmID}); err != nil {
+		if err := b.Network.sendMessageWithRetry(l.GetRemotePeer(), l, FinishStreamID, FinishStreamMsg{StrmID: b.StrmID}); err != nil {
 			glog.Errorf("Error broadcasting finish: %v", err)
 		}
 	}
@@ -92,7 +92,7 @@ func (b *BasicBroadcaster) sendDataMsg(lid string, l OutStream, msg *StreamDataM
 		return
 	}
 
-	if err := l.SendMessage(StreamDataID, StreamDataMsg{SeqNo: msg.SeqNo, StrmID: b.StrmID, Data: msg.Data}); err != nil {
+	if err := b.Network.sendMessageWithRetry(l.GetRemotePeer(), l, StreamDataID, StreamDataMsg{SeqNo: msg.SeqNo, StrmID: b.StrmID, Data: msg.Data}); err != nil {
 		glog.Errorf("Error broadcasting segment %v to listener %v: %v", msg.SeqNo, lid, err)
 		delete(b.listeners, lid)
 	}

--- a/basic_network.go
+++ b/basic_network.go
@@ -214,6 +214,7 @@ func (n *BasicVideoNetwork) connectPeerInfo(info peerstore.PeerInfo) error {
 }
 
 //SendTranscodeResponse sends the transcode result to the broadcast node.
+func (n *BasicVideoNetwork) SendTranscodeResponse(broadcaster string, strmID string, transcodedVideos map[string]string) error {
 	//Don't do anything if the node is the transcoder and the broadcaster at the same time.
 	if n.GetNodeID() == broadcaster {
 		glog.Infof("CurrentNode: %v, broadcaster: %v", n.GetNodeID(), broadcaster)

--- a/basic_network.go
+++ b/basic_network.go
@@ -95,7 +95,7 @@ func NewBasicVideoNetwork(n *BasicNetworkNode, workDir string) (*BasicVideoNetwo
 		mplChans:               make(map[string]chan *m3u8.MasterPlaylist),
 		msgChans:               make(map[string]chan *Msg),
 		transResponseCallbacks: make(map[string]func(transcodeResult map[string]string)),
-		msgCounts:              make(map[Opcode]int)}
+		msgCounts:              make(map[Opcode]int64)}
 	n.Network = nw
 
 	//Set up a worker to write connections

--- a/basic_out_stream.go
+++ b/basic_out_stream.go
@@ -18,6 +18,7 @@ import (
 var ErrOutStream = errors.New("ErrOutStream")
 
 type OutStream interface {
+	GetRemotePeer() peer.ID
 	SendMessage(opCode Opcode, data interface{}) error
 }
 
@@ -27,6 +28,10 @@ type LocalOutStream struct {
 
 func NewLocalOutStream(s *BasicSubscriber) *LocalOutStream {
 	return &LocalOutStream{sub: s}
+}
+
+func (bs *LocalOutStream) GetRemotePeer() peer.ID {
+	return ""
 }
 
 func (bs *LocalOutStream) SendMessage(opCode Opcode, data interface{}) error {
@@ -63,6 +68,10 @@ func NewBasicOutStream(s net.Stream) *BasicOutStream {
 		enc:    enc,
 		el:     &sync.Mutex{},
 	}
+}
+
+func (bs *BasicOutStream) GetRemotePeer() peer.ID {
+	return bs.Stream.Conn().RemotePeer()
 }
 
 //SendMessage writes a message into the stream.

--- a/basic_subscriber.go
+++ b/basic_subscriber.go
@@ -81,7 +81,7 @@ func (s *BasicSubscriber) Subscribe(ctx context.Context, gotData func(seqNo uint
 		if ns != nil {
 			//Send SubReq
 			glog.Infof("Sending Req %v", s.StrmID)
-			if err := ns.SendMessage(SubReqID, SubReqMsg{StrmID: s.StrmID}); err != nil {
+			if err := s.Network.sendMessageWithRetry(p, ns, SubReqID, SubReqMsg{StrmID: s.StrmID}); err != nil {
 				glog.Errorf("Error sending SubReq to %v: %v", peer.IDHexEncode(p), err)
 			}
 			ctxW, cancel := context.WithCancel(context.Background())
@@ -120,7 +120,7 @@ func (s *BasicSubscriber) startWorker(ctxW context.Context, ws *BasicOutStream, 
 				//Send EOF
 				go gotData(0, nil, true)
 				if ws != nil {
-					if err := ws.SendMessage(CancelSubID, CancelSubMsg{StrmID: s.StrmID}); err != nil {
+					if err := s.Network.sendMessageWithRetry(ws.Stream.Conn().RemotePeer(), ws, CancelSubID, CancelSubMsg{StrmID: s.StrmID}); err != nil {
 						glog.Errorf("Error sending CancelSubMsg during worker cancellation: %v", err)
 					}
 				}

--- a/network_node.go
+++ b/network_node.go
@@ -136,7 +136,9 @@ func (n *BasicNetworkNode) GetOutStream(pid peer.ID) *BasicOutStream {
 func (n *BasicNetworkNode) RefreshOutStream(pid peer.ID) *BasicOutStream {
 	// glog.Infof("Creating stream from %v to %v", peer.IDHexEncode(n.Identity), peer.IDHexEncode(pid))
 	if s, ok := n.outStreams[pid]; ok {
-		s.Stream.Reset()
+		if err := s.Stream.Reset(); err != nil {
+			glog.Errorf("Error resetting connetion: %v", err)
+		}
 	}
 
 	ns, err := n.PeerHost.NewStream(context.Background(), pid, Protocol)


### PR DESCRIPTION
The logic change here is adding `sendMessageWithRetry`.  This fixes the following bug:

* n1 -> n2
* n1 sends a bad message (maybe the network drops a few bytes, etc)
* n2 catches the error, breaks out of the handler loop and closes the connection.
* Now n1 doesn't know about it.  It'll continue to send messages on a closed connection.

With the retry, n1 catches the error and attempts to re-establish the connection.