### PR TITLE
Return an err if sending to a nil BasicOutStream.

### DIFF
--- a/basic_out_stream.go
+++ b/basic_out_stream.go
@@ -85,6 +85,7 @@ func (bs *BasicOutStream) SendMessage(opCode Opcode, data interface{}) error {
 func (bs *BasicOutStream) encodeAndFlush(n interface{}) error {
 	if bs == nil {
 		fmt.Println("stream is nil")
+		return ErrOutStream
 	}
 
 	bs.el.Lock()


### PR DESCRIPTION
Prevents a segfault further down in the same method.

The segfault was reproducible under the following scenario  on devenv:

0. Begin broadcasting (also act as bootnode for transcoder)
1. Transcoding begins.
2. Kill transcoder (ctrl-C in this case; not sure if this was a 'clean' kill as far as TCP teardowns go).
3. Broadcaster / bootnode attempts to reconnect to transcoder
4. Reconnect fails
5. Broadcaster tries to send a data message anyway
6. 💥 

By returning ErrOutStream here, the listener also gets removed and the broadcaster no longer attempts to send data.