### PR TITLE
Now we can just use 0.0.0.0 - infered by the libp2p chat example

### DIFF
--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -52,7 +52,7 @@ func TestReconnect(t *testing.T) {
 		t.Errorf("Error closing host: %v", err)
 	}
 	priv2, pub2, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
-	no2, _ := NewNode(15001, priv2, pub2, &BasicNotifiee{})
+	no2, _ := NewNode(addrs(15001), priv2, pub2, &BasicNotifiee{})
 	n2, _ = NewBasicVideoNetwork(no2, "")
 	go n2.SetupProtocol()
 	connectHosts(n1.NetworkNode.(*BasicNetworkNode).PeerHost, n2.NetworkNode.(*BasicNetworkNode).PeerHost)
@@ -269,10 +269,10 @@ func TestSubPeerForwardPath(t *testing.T) {
 	})
 	// glog.Infof("keys: %v", keys)
 
-	no1, _ := NewNode(15000, keys[0].Priv, keys[0].Pub, &BasicNotifiee{})
+	no1, _ := NewNode(addrs(15000), keys[0].Priv, keys[0].Pub, &BasicNotifiee{})
 	n1, _ := NewBasicVideoNetwork(no1, "")
-	no2, _ := NewNode(15001, keys[1].Priv, keys[1].Pub, &BasicNotifiee{})
-	no3, _ := NewNode(15000, keys[2].Priv, keys[2].Pub, &BasicNotifiee{}) //Make this node unreachable from n1 because it's using the same port
+	no2, _ := NewNode(addrs(15001), keys[1].Priv, keys[1].Pub, &BasicNotifiee{})
+	no3, _ := NewNode(addrs(15000), keys[2].Priv, keys[2].Pub, &BasicNotifiee{}) //Make this node unreachable from n1 because it's using the same port
 	defer no1.PeerHost.Close()
 	defer n1.NetworkNode.(*BasicNetworkNode).PeerHost.Close()
 	defer no2.PeerHost.Close()

--- a/cmd/example.go
+++ b/cmd/example.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
@@ -34,7 +35,8 @@ func main() {
 	flag.Lookup("logtostderr").Value.Set("true")
 
 	priv, pub, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
-	node, _ := basicnet.NewNode(*p, priv, pub, &basicnet.BasicNotifiee{})
+	sourceMultiAddr, _ := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", *p))
+	node, _ := basicnet.NewNode([]ma.Multiaddr{sourceMultiAddr}, priv, pub, &basicnet.BasicNotifiee{})
 
 	pid, _ := peer.IDHexDecode(*id)
 	if *id != "" {

--- a/network_node.go
+++ b/network_node.go
@@ -2,13 +2,12 @@ package basicnet
 
 import (
 	"context"
-	"fmt"
 	bhost "gx/ipfs/QmNh1kGFFdsPu79KNSaL4NUKUPb4Eiz4KHdMtFY6664RDp/go-libp2p/p2p/host/basic"
 	rhost "gx/ipfs/QmNh1kGFFdsPu79KNSaL4NUKUPb4Eiz4KHdMtFY6664RDp/go-libp2p/p2p/host/routed"
 	host "gx/ipfs/QmNmJZL7FQySMtE2BQuLMuZg2EB2CLEunJJUSVSc9YnnbV/go-libp2p-host"
 	swarm "gx/ipfs/QmSwZMWwFZSUpe5muU2xgTUwppH24KfMwdPXiwbEp2c6G5/go-libp2p-swarm"
 	kb "gx/ipfs/QmTH6VLu3WXfbH3nuLdmscgPWuiPZv3GMJ2YCdzBS5z91T/go-libp2p-kbucket"
-	multiaddr "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
+	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
 	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
 	peerstore "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
 	inet "gx/ipfs/QmXfkENeeBvh3zYA51MaSdGUdBjhQ99cP5WQe8zgr6wchG/go-libp2p-net"
@@ -47,7 +46,7 @@ type BasicNetworkNode struct {
 }
 
 //NewNode creates a new Livepeerd node.
-func NewNode(listenPort int, priv crypto.PrivKey, pub crypto.PubKey, f *BasicNotifiee) (*BasicNetworkNode, error) {
+func NewNode(listenAddrs []ma.Multiaddr, priv crypto.PrivKey, pub crypto.PubKey, f *BasicNotifiee) (*BasicNetworkNode, error) {
 	pid, err := peer.IDFromPublicKey(pub)
 	if err != nil {
 		return nil, err
@@ -59,12 +58,11 @@ func NewNode(listenPort int, priv crypto.PrivKey, pub crypto.PubKey, f *BasicNot
 	store := peerstore.NewPeerstore()
 	store.AddPrivKey(pid, priv)
 	store.AddPubKey(pid, pub)
-	sourceMultiAddr, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", listenPort))
 
 	// Create swarm (implements libP2P Network)
 	netwrk, err := swarm.NewNetwork(
 		context.Background(),
-		[]multiaddr.Multiaddr{sourceMultiAddr},
+		listenAddrs,
 		pid,
 		store,
 		&BasicReporter{})

--- a/network_node_test.go
+++ b/network_node_test.go
@@ -17,9 +17,9 @@ func TestGetOutStream(t *testing.T) {
 	}()
 
 	priv1, pub1, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
-	no1, _ := NewNode(15000, priv1, pub1, &BasicNotifiee{})
+	no1, _ := NewNode(addrs(15000), priv1, pub1, &BasicNotifiee{})
 	priv2, pub2, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
-	no2, _ := NewNode(15001, priv2, pub2, &BasicNotifiee{})
+	no2, _ := NewNode(addrs(15001), priv2, pub2, &BasicNotifiee{})
 	no1.PeerHost.SetStreamHandler(Protocol, func(s net.Stream) {
 	})
 	msgChan := make(chan Msg)


### PR DESCRIPTION
This was breaking our connection logic because we were listening on the wrong interface.