### PR TITLE
logging: Print abbreviated peer IDs.

### DIFF
--- a/basic_network.go
+++ b/basic_network.go
@@ -75,7 +75,7 @@ type BasicVideoNetwork struct {
 func (n *BasicVideoNetwork) String() string {
 	peers := make([]string, 0)
 	for _, p := range n.NetworkNode.GetPeers() {
-		peers = append(peers, fmt.Sprintf("%v[%v]", peer.IDHexEncode(p), n.NetworkNode.GetPeerInfo(p)))
+		peers = append(peers, fmt.Sprintf("%v[%v]", p, n.NetworkNode.GetPeerInfo(p)))
 	}
 	return fmt.Sprintf("\n\nbroadcasters:%v\n\nsubscribers:%v\n\nrelayers:%v\n\npeers:%v\n\nmasterPlaylists:%v\n\n", n.broadcasters, n.subscribers, n.relayers, peers, n.mplMap)
 }
@@ -561,11 +561,11 @@ func (n *BasicVideoNetwork) SetupProtocol() error {
 func streamHandler(nw *BasicVideoNetwork, ws *BasicInStream) error {
 	msg, err := ws.ReceiveMessage()
 	if err != nil {
-		glog.Errorf("Got error decoding msg from %v: %v (%v).", peer.IDHexEncode(ws.Stream.Conn().RemotePeer()), err, reflect.TypeOf(err))
+		glog.Errorf("Got error decoding msg from %v: %v (%v).", ws.Stream.Conn().RemotePeer(), err, reflect.TypeOf(err))
 		return err
 	}
 
-	glog.V(4).Infof("Received a message %v from %v", msg.Op, peer.IDHexEncode(ws.Stream.Conn().RemotePeer()))
+	glog.V(4).Infof("Received a message %v from %v", msg.Op, ws.Stream.Conn().RemotePeer())
 	if msg.Op == GetMasterPlaylistReqID || msg.Op == MasterPlaylistDataID {
 		if nw.msgSentCache.Has(msgSentCacheKey(ws.Stream.Conn().RemotePeer(), msg.Op, msg.Data)) {
 			//Drop the incoming message
@@ -693,7 +693,7 @@ func handleSubReq(nw *BasicVideoNetwork, subReq SubReqMsg, remotePID peer.ID) er
 func handleSub(nw *BasicVideoNetwork, opCode Opcode, strmID string, submsg interface{}, remotePID peer.ID) error {
 	//If we have local broadcaster, just listen.
 	if b := nw.broadcasters[strmID]; b != nil {
-		glog.V(5).Infof("Handling subReq, adding listener %v to broadcaster", peer.IDHexEncode(remotePID))
+		glog.V(5).Infof("Handling subReq, adding listener %v to broadcaster", remotePID)
 		//TODO: Add verification code for the SubNodeID (Make sure the message is not spoofed)
 		b.AddListeningPeer(nw, remotePID)
 
@@ -759,7 +759,7 @@ func handleSub(nw *BasicVideoNetwork, opCode Opcode, strmID string, submsg inter
 			}
 			return nil
 		} else {
-			glog.Errorf("Cannot get stream for peer: %v", peer.IDHexEncode(p))
+			glog.Errorf("Cannot get stream for peer: %v", p)
 		}
 	}
 
@@ -783,7 +783,7 @@ func handleCancelSubReq(nw *BasicVideoNetwork, cr CancelSubMsg, rpeer peer.ID) e
 			ns := nw.NetworkNode.GetOutStream(r.UpstreamPeer)
 			if ns != nil {
 				if err := nw.sendMessageWithRetry(r.UpstreamPeer, ns, CancelSubID, cr); err != nil {
-					glog.Errorf("Error relaying cancel message to %v: %v ", peer.IDHexEncode(r.UpstreamPeer), err)
+					glog.Errorf("Error relaying cancel message to %v: %v ", r.UpstreamPeer, err)
 				}
 			}
 			if _, ok := nw.subscribers[cr.StrmID]; !ok {
@@ -883,7 +883,7 @@ func handleTranscodeResponse(nw *BasicVideoNetwork, remotePID peer.ID, tr Transc
 		s := nw.NetworkNode.GetOutStream(p)
 		if s != nil {
 			if err := nw.sendMessageWithRetry(p, s, TranscodeResponseID, tr); err != nil {
-				glog.Errorf("Error sending Transcoding Response Message to %v", peer.IDHexEncode(p))
+				glog.Errorf("Error sending Transcoding Response Message to %v", p)
 				continue
 			} else {
 				return nil
@@ -1052,7 +1052,7 @@ func handleNodeStatusReqMsg(nw *BasicVideoNetwork, remotePID peer.ID, nsr NodeSt
 
 			s := nw.NetworkNode.GetOutStream(p)
 			if s != nil {
-				glog.V(common.SHORT).Infof("Sending msg to %v", peer.IDHexEncode(p))
+				glog.V(common.SHORT).Infof("Sending msg to %v", p)
 				if err := nw.sendMessageWithRetry(p, s, NodeStatusReqID, NodeStatusReqMsg{NodeID: nsr.NodeID}); err != nil {
 					continue
 				}

--- a/basic_notifiee.go
+++ b/basic_notifiee.go
@@ -31,7 +31,7 @@ func (bn *BasicNotifiee) ListenClose(n net.Network, addr ma.Multiaddr) {
 
 // called when a connection opened
 func (bn *BasicNotifiee) Connected(n net.Network, conn net.Conn) {
-	glog.V(4).Infof("Notifiee - Connected.  Local: %v - Remote: %v", peer.IDHexEncode(conn.LocalPeer()), peer.IDHexEncode(conn.RemotePeer()))
+	glog.V(4).Infof("Notifiee - Connected.  Local: %v - Remote: %v", conn.LocalPeer(), conn.RemotePeer())
 	if bn.monitor != nil {
 		bn.monitor.LogNewConn(peer.IDHexEncode(conn.LocalPeer()), peer.IDHexEncode(conn.RemotePeer()))
 	}
@@ -39,7 +39,7 @@ func (bn *BasicNotifiee) Connected(n net.Network, conn net.Conn) {
 
 // called when a connection closed
 func (bn *BasicNotifiee) Disconnected(n net.Network, conn net.Conn) {
-	glog.V(4).Infof("Notifiee - Disconnected. Local: %v - Remote: %v", peer.IDHexEncode(conn.LocalPeer()), peer.IDHexEncode(conn.RemotePeer()))
+	glog.V(4).Infof("Notifiee - Disconnected. Local: %v - Remote: %v", conn.LocalPeer(), conn.RemotePeer())
 	if bn.monitor != nil {
 		bn.monitor.RemoveConn(peer.IDHexEncode(conn.LocalPeer()), peer.IDHexEncode(conn.RemotePeer()))
 	}
@@ -54,10 +54,10 @@ func (bn *BasicNotifiee) HandleDisconnect(h func(pid peer.ID)) {
 
 // called when a stream opened
 func (bn *BasicNotifiee) OpenedStream(n net.Network, s net.Stream) {
-	glog.V(4).Infof("Notifiee - OpenedStream: %v - %v", peer.IDHexEncode(s.Conn().LocalPeer()), peer.IDHexEncode(s.Conn().RemotePeer()))
+	glog.V(4).Infof("Notifiee - OpenedStream: %v - %v", s.Conn().LocalPeer(), s.Conn().RemotePeer())
 }
 
 // called when a stream closed
 func (bn *BasicNotifiee) ClosedStream(n net.Network, s net.Stream) {
-	glog.V(4).Infof("Notifiee - ClosedStream: %v - %v", peer.IDHexEncode(s.Conn().LocalPeer()), peer.IDHexEncode(s.Conn().RemotePeer()))
+	glog.V(4).Infof("Notifiee - ClosedStream: %v - %v", s.Conn().LocalPeer(), s.Conn().RemotePeer())
 }

--- a/basic_out_stream.go
+++ b/basic_out_stream.go
@@ -98,13 +98,13 @@ func (bs *BasicOutStream) encodeAndFlush(n interface{}) error {
 	defer bs.el.Unlock()
 	err := bs.enc.Encode(n)
 	if err != nil {
-		glog.Errorf("send message encode error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
+		glog.Errorf("send message encode error for peer %v: %v", bs.Stream.Conn().RemotePeer(), err)
 		return err
 	}
 
 	err = bs.w.Flush()
 	if err != nil {
-		glog.Errorf("send message flush error for peer %v: %v", peer.IDHexEncode(bs.Stream.Conn().RemotePeer()), err)
+		glog.Errorf("send message flush error for peer %v: %v", bs.Stream.Conn().RemotePeer(), err)
 		return err
 	}
 

--- a/basic_relayer.go
+++ b/basic_relayer.go
@@ -37,7 +37,7 @@ func (br *BasicRelayer) RelayStreamData(sd *StreamDataMsg) error {
 func (br *BasicRelayer) RelayFinishStream(nw *BasicVideoNetwork, fs FinishStreamMsg) error {
 	for strmID, l := range br.listeners {
 		if err := br.Network.sendMessageWithRetry(l.Stream.Conn().RemotePeer(), l, FinishStreamID, fs); err != nil {
-			glog.Errorf("Error relaying finish stream to %v: %v", peer.IDHexEncode(l.Stream.Conn().RemotePeer()), err)
+			glog.Errorf("Error relaying finish stream to %v: %v", l.Stream.Conn().RemotePeer(), err)
 			delete(br.listeners, strmID)
 		}
 		br.LastRelay = time.Now()
@@ -48,7 +48,7 @@ func (br *BasicRelayer) RelayFinishStream(nw *BasicVideoNetwork, fs FinishStream
 func (br *BasicRelayer) RelayMasterPlaylistData(nw *BasicVideoNetwork, mpld MasterPlaylistDataMsg) error {
 	for strmID, l := range br.listeners {
 		if err := br.Network.sendMessageWithRetry(l.Stream.Conn().RemotePeer(), l, MasterPlaylistDataID, mpld); err != nil {
-			glog.Errorf("Error relaying master playlist data to %v: %v", peer.IDHexEncode(l.Stream.Conn().RemotePeer()), err)
+			glog.Errorf("Error relaying master playlist data to %v: %v", l.Stream.Conn().RemotePeer(), err)
 			delete(br.listeners, strmID)
 		}
 		br.LastRelay = time.Now()
@@ -59,7 +59,7 @@ func (br *BasicRelayer) RelayMasterPlaylistData(nw *BasicVideoNetwork, mpld Mast
 func (br *BasicRelayer) RelayNodeStatusData(nw *BasicVideoNetwork, nsd NodeStatusDataMsg) error {
 	for id, l := range br.listeners {
 		if err := br.Network.sendMessageWithRetry(l.Stream.Conn().RemotePeer(), l, NodeStatusDataID, nsd); err != nil {
-			glog.Errorf("Error relaying node status data to %v: %v", peer.IDHexEncode(l.Stream.Conn().RemotePeer()), err)
+			glog.Errorf("Error relaying node status data to %v: %v", l.Stream.Conn().RemotePeer(), err)
 			delete(br.listeners, id)
 		}
 		br.LastRelay = time.Now()
@@ -75,5 +75,5 @@ func (br *BasicRelayer) AddListener(nw *BasicVideoNetwork, pid peer.ID) {
 }
 
 func (br BasicRelayer) String() string {
-	return fmt.Sprintf("UpstreamPeer: %v, listeners:%v, count:%v", peer.IDHexEncode(br.UpstreamPeer), len(br.listeners), br.dataCount)
+	return fmt.Sprintf("UpstreamPeer: %v, listeners:%v, count:%v", br.UpstreamPeer, len(br.listeners), br.dataCount)
 }

--- a/basic_subscriber.go
+++ b/basic_subscriber.go
@@ -141,7 +141,7 @@ func (s *BasicSubscriber) sendSub(ctx context.Context, opCode Opcode, msg interf
 			continue
 		}
 		//Question: Where do we close the stream? If we only close on "Unsubscribe", we may leave some streams open...
-		glog.V(5).Infof("New peer from kademlia: %v", peer.IDHexEncode(p))
+		glog.V(5).Infof("New peer from kademlia: %v", p)
 		ns := s.Network.NetworkNode.GetOutStream(p)
 		if ns != nil {
 			err = s.Network.sendMessageWithRetry(p, ns, opCode, msg)
@@ -254,7 +254,7 @@ func (s *BasicSubscriber) Connected(n inet.Network, conn inet.Conn) {
 		// Be a good network citizen -- cancel the original sub through the relay
 		if ns := s.Network.NetworkNode.GetOutStream(s.UpstreamPeer); ns != nil {
 			if err := s.Network.sendMessageWithRetry(s.UpstreamPeer, ns, CancelSubID, CancelSubMsg{StrmID: s.StrmID}); err != nil {
-				glog.Errorf("%v Unable to cancel subscription to upstream relay %s", s.Network.NetworkNode.ID(), peer.IDHexEncode(s.UpstreamPeer))
+				glog.Errorf("%v Unable to cancel subscription to upstream relay %s", s.Network.NetworkNode.ID(), s.UpstreamPeer)
 			}
 		}
 		// check for duplicated cxns or subs?

--- a/network_node.go
+++ b/network_node.go
@@ -89,7 +89,7 @@ func NewNode(listenAddrs []ma.Multiaddr, priv crypto.PrivKey, pub crypto.PubKey,
 	}
 	rHost := rhost.Wrap(basicHost, dht)
 
-	glog.V(2).Infof("Created node: %v at %v", peer.IDHexEncode(rHost.ID()), rHost.Addrs())
+	glog.V(2).Infof("Created node: %v at %v", rHost.ID(), rHost.Addrs())
 	nn := &BasicNetworkNode{Identity: pid, Kad: dht, PeerHost: rHost, outStreams: streams, outStreamsLock: &sync.Mutex{}}
 	f.HandleDisconnect(func(pid peer.ID) {
 		nn.RemoveStream(pid)
@@ -124,7 +124,7 @@ func (n *BasicNetworkNode) RefreshOutStream(pid peer.ID) *BasicOutStream {
 
 	ns, err := n.PeerHost.NewStream(context.Background(), pid, Protocol)
 	if err != nil {
-		glog.Errorf("%v Error creating stream to %v: %v", peer.IDHexEncode(n.Identity), peer.IDHexEncode(pid), err)
+		glog.Errorf("%v Error creating stream to %v: %v", n.Identity, pid, err)
 		return nil
 	}
 	strm := NewBasicOutStream(ns)


### PR DESCRIPTION
Easier to distinguish and diagnose issues with rather than using
the full hex-encoded address.