### PR TITLE
Time Cache

### DIFF
--- a/basic_network_test.go
+++ b/basic_network_test.go
@@ -930,7 +930,6 @@ func TestSendTranscodeResponse(t *testing.T) {
 	// 	glog.Infof("relayer should have 1 listener, but got: %v", r.listeners[peer.IDHexEncode(n3.Identity)])
 	// }
 }
-
 func TestHandleGetMasterPlaylist(t *testing.T) {
 	n1, n2 := setupNodes(t, 15000, 15001)
 	n3, n4 := simpleNodes(15003, 15004)
@@ -948,7 +947,11 @@ func TestHandleGetMasterPlaylist(t *testing.T) {
 			if err != nil {
 				break
 			}
-			n3Chan <- msg.Data.(MasterPlaylistDataMsg)
+			switch msg.Data.(type) {
+			case MasterPlaylistDataMsg:
+				n3Chan <- msg.Data.(MasterPlaylistDataMsg)
+			default:
+			}
 		}
 	})
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -66,6 +66,7 @@ func setupDHTS(ctx context.Context, n int, t *testing.T) ([]*kad.IpfsDHT, []host
 }
 
 func setupNodes(t *testing.T, p1, p2 int) (*BasicVideoNetwork, *BasicVideoNetwork) {
+	MsgSentTimeCacheDuration = 0 * time.Millisecond
 	priv1, pub1, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
 	no1, _ := NewNode(addrs(p1), priv1, pub1, &BasicNotifiee{})
 	n1, _ := NewBasicVideoNetwork(no1, "", "127.0.0.1", p1)


### PR DESCRIPTION
Add a cache for outgoing MasterPlaylistReq and MasterPlaylistData messages.

The timecache library is forked from https://github.com/whyrusleeping/timecache.  I added a `sweep` during `Has`, so that the time duration will be take into account in both `Add` and `Has`.  https://github.com/whyrusleeping/timecache/compare/master...ericxtang:master