### PR TITLE
Cancel nonexistent subscriptions.

### DIFF
--- a/basic_network.go
+++ b/basic_network.go
@@ -728,6 +728,17 @@ func handleSub(nw *BasicVideoNetwork, opCode Opcode, strmID string, submsg inter
 		return ErrHandleMsg
 	}
 
+	// ensure we're not actually the target of the (nonexistent) subscription
+	source, err := extractNodeID(strmID)
+	if err == nil && source == nw.NetworkNode.ID() {
+		glog.V(common.SHORT).Infof("Closing subscription to unknown job: %v", strmID)
+		ns := nw.NetworkNode.GetOutStream(remotePID)
+		if ns != nil {
+			nw.sendMessageWithRetry(remotePID, ns, FinishStreamID, FinishStreamMsg{StrmID: strmID})
+		}
+		return nil
+	}
+
 	//Send Sub Req to the network
 	for _, p := range peers {
 		//Don't send it back to the requesting peer


### PR DESCRIPTION
If the broadcast node ID matches the stream ID and there isn't
such a stream being broadcast, send back a finish message.

This may happen if a broadcaster crashes without cleanly EOF'ing
the stream, causing the transcoder to retry indefinitely until
endBlock is met.